### PR TITLE
Add - tic_one function

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -416,7 +416,6 @@ Missing in AstroLib.jl
 * `t_getpsf`
 * `t_group`
 * `ticlabels`
-* `tic_one`
 * `ticpos`
 * `t_nstar`
 * `tnx_eval`

--- a/docs/src/ref.md
+++ b/docs/src/ref.md
@@ -152,7 +152,8 @@ julia> AstroLib.planets["saturn"].mass
 [`sixty()`](@ref),
 [`sphdist()`](@ref),
 [`ten()`](@ref),
-[`tics()`](@ref).
+[`tic_one()`](@ref),
+[`tics()`](@ref),
 [`trueanom()`](@ref),
 [`vactoair()`](@ref)
 

--- a/src/tic_one.jl
+++ b/src/tic_one.jl
@@ -2,9 +2,9 @@
 
 function _tic_one{T<:AbstractFloat}(zmin::T, pixx::T, incr::T, ra::Bool)
     if ra
-        mul = T(4)
+        mul = 4
     else
-        mul = T(60)
+        mul = 60
     end
     min1 = zmin*mul
     incra = abs(incr)
@@ -37,9 +37,9 @@ This routine determines the position in pixels of the first tic.
 
 * `zmin`: astronomical coordinate value at axis zero point (degrees
    or hours).
-* `pixx`: distance in pixels between tic marks (usually obtained from TICS).
+* `pixx`: distance in pixels between tic marks (usually obtained from [tics](@ref)).
 * `incr` - increment in minutes for labels (usually an even number obtained
-   from the procedure TICS).
+   from the procedure [tics](@ref)).
 * `ra` (optional boolean keyword): if true, incremental value being entered
    is in minutes of time, else it is assumed that value is in else it's in minutes of arc.
    Default is false.

--- a/src/tic_one.jl
+++ b/src/tic_one.jl
@@ -1,0 +1,75 @@
+# This file is a part of AstroLib.jl. License is MIT "Expat".
+
+function _tic_one{T<:AbstractFloat}(zmin::T, pixx::T, incr::T, ra::Bool)
+    if ra
+        mul = T(4)
+    else
+        mul = T(60)
+    end
+    min1 = zmin*mul
+    incra = abs(incr)
+    rem = min1 % incra
+    sign = min1*incr
+
+    if sign > 0
+        tic1 = pixx - abs(rem)*pixx/incra
+        min2 = (min1 + incr -rem)/mul
+    else
+        tic1 = abs(rem)*pixx/incra
+        min2 = (min1 - rem)/mul
+    end
+    return min2, tic1
+end
+
+"""
+    tic_one(zmin, pixx, incr[, ra=true]) -> min2, tic1
+
+### Purpose ###
+
+Determine the position of the first tic mark for astronomical images.
+
+### Explanation ###
+
+For use in labelling images with right ascension and declination axes.
+This routine determines the position in pixels of the first tic.
+
+### Arguments ###
+
+* `zmin`: astronomical coordinate value at axis zero point (degrees
+   or hours).
+* `pixx`: distance in pixels between tic marks (usually obtained from TICS).
+* `incr` - increment in minutes for labels (usually an even number obtained
+   from the procedure TICS).
+* `ra` (optional boolean keyword): if true, incremental value being entered
+   is in minutes of time, else it is assumed that value is in else it's in minutes of arc.
+   Default is false.
+
+### Output ###
+
+The 2 tuple `(min2, tic1)`:
+
+* `min2`: astronomical coordinate value at first tic mark
+* `tic1`: position in pixels of first tic mark
+
+### Example ###
+
+Suppose a declination axis has a value of 30.2345 degrees at its
+zero point.  A tic mark is desired every 10 arc minutes, which
+corresponds to 12.74 pixels, with increment for labels being 10 minutes.
+Then
+
+``` julia
+julia> tic_one(30.2345, 12.74, 10)
+(30.333333333333332, 7.554820000000081)
+```
+
+yields values of min2 ≈ 30.333 and tic1 ≈ 7.55482, i.e. the first tic
+mark should be labeled 30 deg 20 minutes and be placed at pixel value
+7.55482.
+
+### Notes ###
+
+Code of this function is based on IDL Astronomy User's Library.
+"""
+tic_one(zmin::Real, pixx::Real, incr::Real, ra::Bool=false) =
+        _tic_one(promote(float(zmin), float(pixx), float(incr))..., ra)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -148,6 +148,9 @@ export sunpos
 include("ten.jl")
 export ten
 
+include("tic_one.jl")
+export tic_one
+
 include("tics.jl")
 export tics
 

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -544,9 +544,8 @@ end
     [-0.37388888888888894, -1.0, -3.0]
 @test ten.([12.0, -0.0], [24, 30]) == ten.([" 12::24", " -0:30: "]) == [12.4, -0.5]
 
-#Test tic_once
-let
-    local min2, tic1
+#Test tic_one
+@testset "tic_one" begin
     min2, tic1 = tic_one(30.2345, 12.74, 10)
     @test min2 ≈ 30.333333333333332
     @test tic1 ≈ 7.554820000000081

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -544,6 +544,20 @@ end
     [-0.37388888888888894, -1.0, -3.0]
 @test ten.([12.0, -0.0], [24, 30]) == ten.([" 12::24", " -0:30: "]) == [12.4, -0.5]
 
+#Test tic_once
+let
+    local min2, tic1
+    min2, tic1 = tic_one(30.2345, 12.74, 10)
+    @test min2 ≈ 30.333333333333332
+    @test tic1 ≈ 7.554820000000081
+    min2, tic1 = tic_one(45, 50, 4, true)
+    @test min2 ≈ 46.0
+    @test tic1 ≈ 50.0
+    min2, tic1 = tic_one(pi\8, tics(90, 45, 1000, 10)[1], tics(90, 45, 1000, 10)[2])
+    @test min2 ≈ 2.5
+    @test tic1 ≈ 1.0318357862412286
+end
+
 #Test tics
 @test tics(30, 90, 30, 1) == (3.8666666666666667, 480)
 @test tics(30, 90, 3, 3, true) == (4.0, 240)

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -552,7 +552,7 @@ end
     min2, tic1 = tic_one(45, 50, 4, true)
     @test min2 ≈ 46.0
     @test tic1 ≈ 50.0
-    min2, tic1 = tic_one(pi\8, tics(90, 45, 1000, 10)[1], tics(90, 45, 1000, 10)[2])
+    min2, tic1 = tic_one(pi\8, tics(90, 45, 1000, 10)...)
     @test min2 ≈ 2.5
     @test tic1 ≈ 1.0318357862412286
 end


### PR DESCRIPTION
* TODO.md: remove 'tic_one' from list.
* docs/src/ref.md: add "tic_one" entry to the manual.
* src/utils.jl: Add tic_one entry to "utils".
* src/tic_one.jl: Contains tic_one function.
* test/util-tests.jl: Include tests

The example given in IDL's tic_one.pro seems to be inaccurate, as it is placing the 2nd argument(pixx =12.74) in the spot of the 3rd argument during function call.
So I modified the example while using it in tic_one.jl. Please review, just in case I'm missing something.