### PR TITLE
Add zenpos function

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -84,7 +84,6 @@ Missing in AstroLib.jl
 * `ticlabels`
 * `uvbybeta`
 * `zang`
-* `zenpos`
 
 ### DAOPHOT-Type Photometry Procedures
 

--- a/docs/src/ref.md
+++ b/docs/src/ref.md
@@ -110,6 +110,7 @@ julia> AstroLib.planets["saturn"].mass
 [`premat()`](@ref),
 [`radec()`](@ref),
 [`recpol()`](@ref)
+[`zenpos()`](@ref)
 
 ### Time and date
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -171,3 +171,6 @@ export ydn2md
 
 include("ymd2dn.jl")
 export ymd2dn
+
+include("zenpos.jl")
+export zenpos

--- a/src/zenpos.jl
+++ b/src/zenpos.jl
@@ -1,15 +1,7 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 
-function _zenpos{T<:AbstractFloat}(jd::T, latitude::T, longitude::T)
-
-    lst = ct2lst(longitude, jd)
-    ra = lst*pi/12
-    dec = ra*0.0 + deg2rad(latitude)
-    return ra, dec
-end
-
 """
-    zenpos(jd, latitude, longitude) -> zenith_right_ascension, declination
+    zenpos(latitude, longitude, jd) -> zenith_right_ascension, declination
     zenpos(date, latitude, longitude, tz) -> zenith_right_ascension, declination
 
 ### Purpose ###
@@ -25,7 +17,7 @@ are converted to radians and returned as the zenith direction.
 
 ### Arguements ###
 
-The function can be called in two different ways.  The arguments common to
+The function can be called in two different ways. The arguments common to
 both methods are `latitude` and `longitude`:
 
 * `latitude` : latitude of the desired location.
@@ -55,24 +47,19 @@ A 2-tuple `(ra, dec)`:
 julia> zenpos(DateTime(2017, 04, 25, 18, 59), 43.16, -24.32, 4)
 (0.946790432684706, 0.7532841051607526)
 
-julia> zenpos(jdcnv(2016, 05, 05, 13, 41), ten(35,0,42), ten(135,46,6))
-(3.575782115277954, 0.6110688599440813)
+julia> zenpos(ten(35,0,42), ten(135,46,6), jdcnv(2016, 05, 05, 13, 41))
+(3.5757821152779536, 0.6110688599440813)
 ```
 
 ### Notes ###
 
 Code of this function is based on IDL Astronomy User's Library.
 """
-zenpos(jd::Real, latitude::Real, longitude::Real) =
-    _zenpos(promote(float(jd), float(latitude), float(longitude))...)
+_zenpos{T<:AbstractFloat}(latitude::T, longitude::T, rest...) =
+    (ct2lst(longitude, rest...) / 12 * pi, deg2rad(latitude))
 
-function zenpos{T<:AbstractFloat}(date::DateTime, latitude::T, longitude::T, tz::T)
-
-    lst = ct2lst(longitude, tz, date)
-    ra = lst*pi/12
-    dec = ra*0.0 + deg2rad(latitude)
-    return ra, dec
-end
+zenpos(latitude::Real, longitude::Real, jd::Real) =
+    _zenpos(promote(float(latitude), float(longitude), float(jd))...)
 
 zenpos(date::DateTime, latitude::Real, longitude::Real, tz::Real) =
-    zenpos(date, promote(float(latitude), float(longitude), float(tz))...)
+    _zenpos(promote(float(latitude), float(longitude), float(tz))..., date)

--- a/src/zenpos.jl
+++ b/src/zenpos.jl
@@ -1,0 +1,78 @@
+# This file is a part of AstroLib.jl. License is MIT "Expat".
+
+function _zenpos{T<:AbstractFloat}(jd::T, latitude::T, longitude::T)
+
+    lst = ct2lst(longitude, jd)
+    ra = lst*pi/12
+    dec = ra*0.0 + deg2rad(latitude)
+    return ra, dec
+end
+
+"""
+    zenpos(jd, latitude, longitude) -> zenith_right_ascension, declination
+    zenpos(date, latitude, longitude, tz) -> zenith_right_ascension, declination
+
+### Purpose ###
+
+Return the zenith right ascension and declination in radians for a given Julian date
+or a local civil time and timezone.
+
+### Explanation ###
+
+The local sidereal time is computed with the help of [ct2lst](@ref), which is the right
+ascension of the zenith. This and the observatories latitude (corresponding to the declination)
+are converted to radians and returned as the zenith direction.
+
+### Arguements ###
+
+The function can be called in two different ways.  The arguments common to
+both methods are `latitude` and `longitude`:
+
+* `latitude` : latitude of the desired location.
+* `longitude` : longitude of the desired location.
+
+The zenith direction can be computed either by providing the Julian date:
+
+* `jd` : the Julian date of the date and time for which the zenith position is
+  desired.
+
+or the time zone and the date:
+
+* `tz`: the time zone (in hours) of the desired location (e.g. 4 = EDT, 5 = EST)
+* `date`: the local civil time with type `DateTime`. It can
+  be a scalar or an array.
+
+### Output ###
+
+A 2-tuple `(ra, dec)`:
+
+* `ra` : the right ascension (in radians) of the zenith.
+* `dec` : the declination (in radians) of the zenith.
+
+### Example ###
+
+``` julia
+julia> zenpos(DateTime(2017, 04, 25, 18, 59), 43.16, -24.32, 4)
+(0.946790432684706, 0.7532841051607526)
+
+julia> zenpos(jdcnv(2016, 05, 05, 13, 41), ten(35,0,42), ten(135,46,6))
+(3.575782115277954, 0.6110688599440813)
+```
+
+### Notes ###
+
+Code of this function is based on IDL Astronomy User's Library.
+"""
+zenpos(jd::Real, latitude::Real, longitude::Real) =
+    _zenpos(promote(float(jd), float(latitude), float(longitude))...)
+
+function zenpos{T<:AbstractFloat}(date::DateTime, latitude::T, longitude::T, tz::T)
+
+    lst = ct2lst(longitude, tz, date)
+    ra = lst*pi/12
+    dec = ra*0.0 + deg2rad(latitude)
+    return ra, dec
+end
+
+zenpos(date::DateTime, latitude::Real, longitude::Real, tz::Real) =
+    zenpos(date, promote(float(latitude), float(longitude), float(tz))...)

--- a/src/zenpos.jl
+++ b/src/zenpos.jl
@@ -1,7 +1,7 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 
 """
-    zenpos(latitude, longitude, jd) -> zenith_right_ascension, declination
+    zenpos(jd, latitude, longitude) -> zenith_right_ascension, declination
     zenpos(date, latitude, longitude, tz) -> zenith_right_ascension, declination
 
 ### Purpose ###
@@ -15,7 +15,7 @@ The local sidereal time is computed with the help of [ct2lst](@ref), which is th
 ascension of the zenith. This and the observatories latitude (corresponding to the declination)
 are converted to radians and returned as the zenith direction.
 
-### Arguements ###
+### Arguments ###
 
 The function can be called in two different ways. The arguments common to
 both methods are `latitude` and `longitude`:
@@ -47,7 +47,7 @@ A 2-tuple `(ra, dec)`:
 julia> zenpos(DateTime(2017, 04, 25, 18, 59), 43.16, -24.32, 4)
 (0.946790432684706, 0.7532841051607526)
 
-julia> zenpos(ten(35,0,42), ten(135,46,6), jdcnv(2016, 05, 05, 13, 41))
+julia> zenpos(jdcnv(2016, 05, 05, 13, 41), ten(35,0,42), ten(135,46,6))
 (3.5757821152779536, 0.6110688599440813)
 ```
 
@@ -55,10 +55,12 @@ julia> zenpos(ten(35,0,42), ten(135,46,6), jdcnv(2016, 05, 05, 13, 41))
 
 Code of this function is based on IDL Astronomy User's Library.
 """
+zenpos
+
 _zenpos{T<:AbstractFloat}(latitude::T, longitude::T, rest...) =
     (ct2lst(longitude, rest...) / 12 * pi, deg2rad(latitude))
 
-zenpos(latitude::Real, longitude::Real, jd::Real) =
+zenpos(jd::Real, latitude::Real, longitude::Real) =
     _zenpos(promote(float(latitude), float(longitude), float(jd))...)
 
 zenpos(date::DateTime, latitude::Real, longitude::Real, tz::Real) =

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -642,13 +642,13 @@ end
 
 # Test zenpos
 @testset "zenpos" begin
-    ra, dec = zenpos(2.457514070138889e6, 45, 45)
+    ra, dec = zenpos(45, 45, 2.457514070138889e6)
     @test ra ≈ 1.9915758420649625
     @test dec ≈ 0.7853981633974483
     ra, dec = zenpos(DateTime(2015, 11, 24, 13, 21), 43.16, -24.32, 4)
     @test ra ≈ 3.1232737646297757
     @test dec ≈ 0.7532841051607526
-    ra, dec = zenpos(jdcnv(2017, 01, 30, 04, 30), ten(35,0,42), ten(135,46,6))
+    ra, dec = zenpos(ten(35,0,42), ten(135,46,6), jdcnv(2017, 01, 30, 04, 30))
     @test ra ≈ 5.809762417608341
     @test dec ≈ 0.6110688599440813
 end

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -639,3 +639,16 @@ end
 # Test ymd2dn
 @test ymd2dn.([Date(2015,3,5), Date(2016,3,5)]) == [64, 65]
 @test ydn2md(2016, ymd2dn(Date(2016, 09, 16))) == Date(2016, 09, 16)
+
+# Test zenpos
+@testset "zenpos" begin
+    ra, dec = zenpos(2.457514070138889e6, 45, 45)
+    @test ra ≈ 1.9915758420649625
+    @test dec ≈ 0.7853981633974483
+    ra, dec = zenpos(DateTime(2015, 11, 24, 13, 21), 43.16, -24.32, 4)
+    @test ra ≈ 3.1232737646297757
+    @test dec ≈ 0.7532841051607526
+    ra, dec = zenpos(jdcnv(2017, 01, 30, 04, 30), ten(35,0,42), ten(135,46,6))
+    @test ra ≈ 5.809762417608341
+    @test dec ≈ 0.6110688599440813
+end

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -642,13 +642,13 @@ end
 
 # Test zenpos
 @testset "zenpos" begin
-    ra, dec = zenpos(45, 45, 2.457514070138889e6)
+    ra, dec = zenpos(2.457514070138889e6, 45, 45)
     @test ra ≈ 1.9915758420649625
     @test dec ≈ 0.7853981633974483
     ra, dec = zenpos(DateTime(2015, 11, 24, 13, 21), 43.16, -24.32, 4)
     @test ra ≈ 3.1232737646297757
     @test dec ≈ 0.7532841051607526
-    ra, dec = zenpos(ten(35,0,42), ten(135,46,6), jdcnv(2017, 01, 30, 04, 30))
+    ra, dec = zenpos(jdcnv(2017, 01, 30, 04, 30), ten(35,0,42), ten(135,46,6))
     @test ra ≈ 5.809762417608341
     @test dec ≈ 0.6110688599440813
 end


### PR DESCRIPTION
* TODO.md: Remove 'zenpos' from list.
* docs/src/ref.md: Add "zenpos" entry to the manual.
* src/utils.jl: Add zenpos entry to "utils".
* src/zenpos.jl: Contains code of zenpos function.
* test/util-tests.jl: Include tests for zenpos.

The arguments given in IDL's zenpos.pro's call to ct2lst seems slightly off, as its calling both timezone and julian date.
However, timezone is essentially a dummy (as noted in calling sequence of ct2lst.pro).
So I've written two ways to call the function - one which takes Julian date as an argument and one which takes local date and timezone.