### PR TITLE
Add co_aberration function and sunpos function bugfix 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -61,7 +61,6 @@ Missing in AstroLib.jl
 * `astro`
 * `baryvel`
 * `ccm_unred` (should go to [DustExtinction.jl](DustExtinction.jl))
-* `co_aberration`
 * `co_nutate`
 * `co_refract`
 * `date`

--- a/docs/src/ref.md
+++ b/docs/src/ref.md
@@ -92,6 +92,7 @@ julia> AstroLib.planets["saturn"].mass
 [`aitoff()`](@ref),
 [`altaz2hadec()`](@ref),
 [`bprecess()`](@ref)
+[`co_aberration()`](@ref),
 [`eci2geo()`](@ref)
 [`eqpole()`](@ref)
 [`gcirc()`](@ref)

--- a/src/co_aberration.jl
+++ b/src/co_aberration.jl
@@ -1,0 +1,89 @@
+# This file is a part of AstroLib.jl. License is MIT "Expat".
+
+function _co_aberration{T<:AbstractFloat}(jd::T, ra::T, dec::T, eps::T)
+    t = (jd - 2415020.0)*inv(JULIANYEAR*100)
+    if isnan(eps)
+        eps0 = ten(23,26,21.448)*3600 - 46.815*t - 0.00058*(t^2) +
+               0.001813*(t^3)
+        eps = sec2rad(eps0 + nutate(jd)[2])
+    end
+    sunlong = T(sunpos(jd, radians=true)[3])
+    e = 0.016708634 - 0.000042037*t - 0.0000001267*(t^2)
+    pe = 102.93735 + 1.71946*t + 0.00046*(t^2)
+    cd = cosd(dec)
+    sd = sind(dec)
+    ce = cos(eps)
+    te = tan(eps)
+    cp = cosd(pe)
+    sp = sind(pe)
+    cs = cos(sunlong)
+    ss = sin(sunlong)
+    ca = cosd(ra)
+    sa = sind(ra)
+    t1 = (cs*ce*(te*cd - sa*sd) + ca*sd*ss)
+    t2 = (cp*ce*(te*cd - sa*sd) + ca*sd*sp)
+    d_ra = 20.49552*(e*(ca*cp*ce + sa*sp) - ca*cs*ce + sa*ss)/cd
+    d_dec = 20.49552*(e*t2 - t1)
+    return d_ra, d_dec
+end
+
+"""
+
+
+### Purpose ###
+
+Calculate changes to right ascension and declination due to the effect
+of annual aberration
+
+### Explanation ###
+
+With reference to Meeus, Chapter 23
+
+### Arguments ###
+
+* `jd`: julian date, scalar or vector
+* `ra`: right ascension in degrees, scalar or vector
+* `dec`: declination in degrees, scalar or vector
+* `eps` (optional): true obliquity of the ecliptic (in radians). It will be
+  calculated if no argument is specified.
+
+### Output ###
+
+The 2-tuple `(d_ra, d_dec)`:
+
+* `d_ra`: correction to right ascension due to aberration, in arc seconds
+* `d_dec`: correction to declination due to aberration, in arc seconds
+
+### Example ###
+
+```julia
+
+```
+
+### Notes ###
+
+Code of this function is based on IDL Astronomy User's Library.
+
+The output d_ra is *not* multiplied by cos(dec), so that
+apparent_ra = ra + d_ra/3600.
+
+These formula are from Meeus, Chapters 23.  Accuracy is much better than 1
+arcsecond. The maximum deviation due to annual aberration is 20.49'' and occurs when the
+Earth's velocity is perpendicular to the direction of the star.
+
+This function calls [nutate](@ref), [ten](@ref) and [sunpos](@ref).
+"""
+co_aberration(jd::Real, ra::Real, dec::Real; eps::Real=NaN) =
+    _co_aberration(promote(float(jd), float(ra), float(dec), float(eps))...)
+
+function co_aberration{R<:Real}(jd::AbstractVector{R}, ra::AbstractVector{R},
+                                dec::AbstractVector{R}; eps::Real=NaN)
+    @assert length(jd) == length(ra) == length(dec) "jd, ra and dec vectors should be of the same length"
+    typejd = typeof(float(one(R)))
+    ra_out  = similar(ra,  typejd)
+    dec_out = similar(dec, typejd)
+    for i in eachindex(jd)
+        ra_out[i], dec_out[i] = co_aberration(jd[i], ra[i], dec[i], eps=eps)
+    end
+    return ra_out, dec_out
+end

--- a/src/co_aberration.jl
+++ b/src/co_aberration.jl
@@ -1,7 +1,7 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 
 function _co_aberration{T<:AbstractFloat}(jd::T, ra::T, dec::T, eps::T)
-    t = (jd - 2415020.0)*inv(JULIANYEAR*100)
+    t = (jd -2451545)/36525
     if isnan(eps)
         eps0 = ten(23,26,21.448)*3600 - 46.815*t - 0.00058*(t^2) +
                0.001813*(t^3)
@@ -22,7 +22,7 @@ function _co_aberration{T<:AbstractFloat}(jd::T, ra::T, dec::T, eps::T)
     sa = sind(ra)
     t1 = (cs*ce*(te*cd - sa*sd) + ca*sd*ss)
     t2 = (cp*ce*(te*cd - sa*sd) + ca*sd*sp)
-    d_ra = 20.49552*(e*(ca*cp*ce + sa*sp) - ca*cs*ce + sa*ss)/cd
+    d_ra = 20.49552*(e*(ca*cp*ce + sa*sp) - ca*cs*ce - sa*ss)/cd
     d_dec = 20.49552*(e*t2 - t1)
     return d_ra, d_dec
 end
@@ -56,8 +56,18 @@ The 2-tuple `(d_ra, d_dec)`:
 
 ### Example ###
 
-```julia
+Compute the change in RA and Dec of Theta Persei (RA = 2h46m,11.331s, Dec = 49d20',54.5'')
+due to aberration on 2028 Nov 13.19 TD
 
+```julia
+julia> jd = jdcnv(2028,11,13,4, 56)
+2.4620887055555554e6
+
+julia> co_aberration(jd,ten(2,46,11.331)*15,ten(49,20,54.54))
+(30.044044923858255, 6.699402837501943)
+
+d_ra = 30.044044923858255'' (≈ 2.003s)
+d_dec = 6.699402837501943''
 ```
 
 ### Notes ###

--- a/src/precess_cd.jl
+++ b/src/precess_cd.jl
@@ -31,7 +31,7 @@ function _precess_cd{T<:AbstractFloat}(cd::AbstractMatrix{T}, epoch1::T, epoch2:
 end
 
 """
-    precess_cd(cd, epoch1, epoch2, crval_old, crval_new) -> cd
+    precess_cd(cd, epoch1, epoch2, crval_old, crval_new[, FK4=true]) -> cd
 
 ### Purpose ###
 
@@ -49,8 +49,9 @@ The coordinate matrix is precessed from epoch1 to epoch2.
 * `crval_old`: 2 element vector containing right ascension and declination
   in degrees of the reference pixel in the original equinox
 * `crval_new`: 2 element vector giving crval in the new equinox
-* `FK4` (optional boolean keyword): if this keyword is set, then the precession constants
-  are taken in the FK4 reference frame. The default is the FK5 frame
+* `FK4` (optional boolean keyword): if this keyword is set to `true`,
+  then the precession constants are taken in the FK4 reference frame. When it
+  is `false`, the default is the FK5 frame
 
 ### Output ###
 

--- a/src/sunpos.jl
+++ b/src/sunpos.jl
@@ -40,7 +40,7 @@ function _sunpos{T<:AbstractFloat}(jd::T, radians::Bool)
     longterm = 6.4*sind(231.19 + 20.20*t)
     l += longterm
     l  = mod(l + 2592000.0, 1296000.0)
-    longmed = l/3600.0
+    longmed = deg2rad(l/3600)
     # Allow for Aberration
     l -= 20.5
     # Allow for Nutation using the longitude of the Moons mean node OMEGA
@@ -52,10 +52,11 @@ function _sunpos{T<:AbstractFloat}(jd::T, radians::Bool)
     l /= 3600.0
     ra = cirrange(atan2(sind(l)*cosd(oblt), cosd(l)), 2pi)
     dec = asin(sind(l)*sind(oblt))
+    oblt = deg2rad(oblt)
     if radians
-        return ra, dec, deg2rad(longmed), deg2rad(oblt)
+        return ra, dec, longmed, oblt
     else
-        return rad2deg(ra), rad2deg(dec), longmed, oblt
+        return rad2deg(ra), rad2deg(dec), rad2deg(longmed), rad2deg(oblt)
     end
 end
 

--- a/src/sunpos.jl
+++ b/src/sunpos.jl
@@ -53,9 +53,9 @@ function _sunpos{T<:AbstractFloat}(jd::T, radians::Bool)
     ra = cirrange(atan2(sind(l)*cosd(oblt), cosd(l)), 2pi)
     dec = asin(sind(l)*sind(oblt))
     if radians
-        return ra, dec, longmed, oblt
+        return ra, dec, deg2rad(longmed), deg2rad(oblt)
     else
-        return rad2deg(ra), rad2deg(dec), rad2deg(longmed), rad2deg(oblt)
+        return rad2deg(ra), rad2deg(dec), longmed, oblt
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,6 +19,9 @@ export bprecess
 include("calz_unred.jl")
 export calz_unred
 
+include("co_aberration.jl")
+export co_aberration
+
 include("ct2lst.jl")
 export ct2lst
 

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -68,15 +68,14 @@ end
 # correlated with the output from co_aberration routine of IDL AstroLib, with
 # very small differences.
 @testset "co_aberration" begin
-    d_ra, d_dec = co_aberration(jdcnv(1987, 4, 10, 0), ten(2,46,11.331)*15, ten(49,20,54.54),
-                                eps=1)
+    d_ra, d_dec = co_aberration(jdcnv(1987, 4, 10, 0), ten(2,46,11.331)*15, ten(49,20,54.54), 1)
     @test d_ra ≈ -18.692441865574867
     @test d_dec ≈ -9.070782150537646
     ao, bo =  co_aberration([57555.0, -6.44311e5], [302.282, 69.5667], [37.1519, 20.6847])
     @test ao[1] ≈ 21.67305848435842
-    @test ao[2] ≈ 18.497092503678395
+    @test ao[2] ≈ 18.497093350858627
     @test bo[1] ≈ -6.773074833128152
-    @test bo[2] ≈ 2.9168653394094504
+    @test bo[2] ≈ 2.916859869619659
 end
 
 # Test ct2lst

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -66,7 +66,7 @@ end
 # Test co_aberration
 # The values used for the testset are from running the code. However they have been
 # correlated with the output from co_aberration routine of IDL AstroLib, with
-# differences only in the least significant digits.
+# very small differences.
 @testset "co_aberration" begin
     d_ra, d_dec = co_aberration(jdcnv(1987, 4, 10, 0), ten(2,46,11.331)*15, ten(49,20,54.54),
                                 eps=1)

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -63,7 +63,23 @@ end
      0.7080829505773865, 0.7502392743978797, 0.7861262388745882, 0.8151258710444882,
      0.8390325371659836]
 
-#test ct2lst
+# Test co_aberration
+# The values used for the testset are from running the code. However they have been
+# correlated with the output from co_aberration routine of IDL AstroLib, with
+# differences only in the least significant digits.
+@testset "co_aberration" begin
+    d_ra, d_dec = co_aberration(jdcnv(1987, 4, 10, 0), ten(2,46,11.331)*15, ten(49,20,54.54),
+                                eps=1)
+    @test d_ra ≈ -18.692441865574867
+    @test d_dec ≈ -9.070782150537646
+    ao, bo =  co_aberration([57555.0, -6.44311e5], [302.282, 69.5667], [37.1519, 20.6847])
+    @test ao[1] ≈ 21.67305848435842
+    @test ao[2] ≈ 18.497092503678395
+    @test bo[1] ≈ -6.773074833128152
+    @test bo[2] ≈ 2.9168653394094504
+end
+
+# Test ct2lst
 @test ct2lst.(-76.72, -4, [DateTime(2008, 7, 30, 15, 53)]) ≈ [11.356505172312609]
 @test ct2lst.(9, [jdcnv(2015, 11, 24, 12, 21)]) ≈ [17.159574059885927]
 
@@ -82,7 +98,6 @@ let
     @test c0  ≈ [0.905,1.0]
     @test ub0 ≈ [-0.665,0.3]
 end
-
 
 # Test eci2geo
 let
@@ -552,23 +567,22 @@ end
 @test sphdist.(120, -43, [175], [+22]) ≈ [1.5904422616007134]
 
 # Test sunpos
-let
-    local ra, dec, lon, obl
+@testset "sunpos" begin
     ra, dec, lon, obl = sunpos(jdcnv(1982, 5, 1))
     @test ra  ≈ 37.88589057369026
     @test dec ≈ 14.909699471099517
-    @test lon ≈ 2309.6312912217463
-    @test obl ≈ 1343.0612563977593
+    @test lon ≈ 40.31067053890748
+    @test obl ≈ 23.440840980112657
     ra, dec, lon, obl = sunpos(jdcnv.([DateTime(2016, 5, 10)]), radians=true)
     @test ra  ≈ [0.8259691339090751]
     @test dec ≈ [0.3085047454107549]
-    @test lon ≈ [49.77773359512005 ]
-    @test obl ≈ [23.434647165246304]
+    @test lon ≈ [0.8687853454154388]
+    @test obl ≈ [0.40901175207670365]
     ra, dec, lon, obl = sunpos([2457531])
     @test ra  ≈ [59.71655864208797]
     @test dec ≈ [20.52127006818727]
-    @test lon ≈ [3542.279299068626]
-    @test obl ≈ [1342.7064622183311]
+    @test lon ≈ [61.824436793991545]
+    @test obl ≈ [23.434648653514724]
 end
 
 # Test "ten" and "tenv".  Always make sure string and numerical inputs are


### PR DESCRIPTION
The sunpos function gave the wrong output of `elong` and `obliquity`, because they were
in degrees from the start and so didn't need to be converted again into degrees. Verified with values from sunpos.pro (IDL AstroLib). The bug was found as it propagated into the output of co_aberration function.

* src/sunpos.jl: Bugfix
* TODO.md: Remove 'co_aberration' from list.
* docs/src/ref.md: Add "co_aberration" entry to the manual.
* src/utils.jl: Add co_aberration entry to "utils".
* src/co_aberration.jl: Contains code of co_aberration function.
* test/util-tests.jl: Include tests for co_aberration.