### PR TITLE
Add co_nutate function and split obliquity function

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -61,7 +61,6 @@ Missing in AstroLib.jl
 * `astro`
 * `baryvel`
 * `ccm_unred` (should go to [DustExtinction.jl](DustExtinction.jl))
-* `co_nutate`
 * `co_refract`
 * `date`
 * `date_conv`

--- a/docs/src/ref.md
+++ b/docs/src/ref.md
@@ -106,7 +106,7 @@ julia> AstroLib.planets["saturn"].mass
 [`helio_rv()`](@ref),
 [`jprecess()`](@ref),
 [`mag2geo()`](@ref),
-[`obliquity()`](@ref),
+[`mean_obliquity()`](@ref),
 [`polrec()`](@ref),
 [`posang()`](@ref),
 [`precess()`](@ref),
@@ -115,6 +115,7 @@ julia> AstroLib.planets["saturn"].mass
 [`premat()`](@ref),
 [`radec()`](@ref),
 [`recpol()`](@ref),
+[`true_obliquity()`](@ref),
 [`zenpos()`](@ref)
 
 ### Time and date

--- a/docs/src/ref.md
+++ b/docs/src/ref.md
@@ -93,6 +93,7 @@ julia> AstroLib.planets["saturn"].mass
 [`altaz2hadec()`](@ref),
 [`bprecess()`](@ref),
 [`co_aberration()`](@ref),
+[`co_nutate()`](@ref),
 [`eci2geo()`](@ref),
 [`eqpole()`](@ref),
 [`euler()`](@ref),

--- a/src/co_aberration.jl
+++ b/src/co_aberration.jl
@@ -3,7 +3,7 @@
 function _co_aberration{T<:AbstractFloat}(jd::T, ra::T, dec::T, eps::T)
     t = (jd - J2000)*inv(JULIANYEAR*100)
     if isnan(eps)
-        eps = obliquity(jd)
+        eps = true_obliquity(jd)
     end
     sunlong = sunpos(jd, radians=true)[3]
     e = @evalpoly t 0.016708634 -0.000042037 -0.0000001267
@@ -79,7 +79,7 @@ These formula are from Meeus, Chapters 23.  Accuracy is much better than 1
 arcsecond. The maximum deviation due to annual aberration is 20.49'' and occurs when the
 Earth's velocity is perpendicular to the direction of the star.
 
-This function calls [obliquity](@ref) and [sunpos](@ref).
+This function calls [true_obliquity](@ref) and [sunpos](@ref).
 """
 co_aberration(jd::Real, ra::Real, dec::Real, eps::Real=NaN) =
     _co_aberration(promote(float(jd), float(ra), float(dec), float(eps))...)

--- a/src/co_nutate.jl
+++ b/src/co_nutate.jl
@@ -2,7 +2,7 @@
 
 function _co_nutate(jd::T, ra::T, dec::T) where {T<:AbstractFloat}
     d_psi, d_eps = nutate(jd)
-    eps = obliquity(jd)
+    eps = mean_obliquity(jd) + sec2rad(d_eps)
     ce = cos(eps)
     se = sin(eps)
     x = cosd(ra) * cosd(dec)
@@ -78,7 +78,7 @@ Code of this function is based on IDL Astronomy User's Library.
 The output of `d_ra` and `d_dec` in IDL AstroLib is in arcseconds,
 however it is in degrees here.
 
-This function calls [obliquity](@ref) and [nutate](@ref).
+This function calls [mean_obliquity](@ref) and [nutate](@ref).
 """
 co_nutate(jd::Real, ra::Real, dec::Real) =
     _co_nutate(promote(float(jd), float(ra), float(dec))...)

--- a/src/co_nutate.jl
+++ b/src/co_nutate.jl
@@ -1,12 +1,34 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 
-function _co_nutate{T<:AbstractFloat}(jd::T, ra::T, dec::T)
-    
+function _co_nutate(jd::T, ra::T, dec::T) where {T<:AbstractFloat}
+    t = (jd - J2000) / (JULIANYEAR*100)
+    d_psi, d_eps = nutate(jd)
+    eps0 = @evalpoly t 84381.406 -46.836769 -0.0001831 0.0020034 -0.576e-6 -4.34e-8
+    eps = sec2rad(eps0 + d_eps)
+    ce = cos(eps)
+    se = sin(eps)
+    x = cosd(ra) * cosd(dec)
+    y = sind(ra) * cosd(dec)
+    z = sind(dec)
+    x2 = x - sec2rad(y * ce + z * ce) * d_psi
+    y2 = y + sec2rad(x * ce * d_psi - z * d_eps)
+    z2 = z + sec2rad(x * se * d_psi + y * d_eps)
+    r = sqrt(x2^2 + y2^2 + z2^2)
+    xyproj = sqrt(x2^2 + y2^2)
+    ra2 = atan2(y2, x2)
+    dec2 = asin(z2/r)
+    ra2 = rad2deg(ra2)
 
+    if ra2 < 0
+        ra2 += 360
+    end
+    d_ra = ra2 - ra
+    d_dec = rad2deg(dec2) - dec
+    return d_ra, d_dec, eps, d_psi, d_eps
 end
 
 """
-    co_nutate()
+    co_nutate(jd, ra, dec) -> d_ra, d_dec, eps, d_psi, d_eps
 
 ### Purpose ###
 
@@ -15,10 +37,10 @@ Earth's rotation
 
 ### Explanation ###
 
-Calculates necessary changes to ra and dec due to the nutation of the Earth's rotation
-axis, as described in Meeus, Chap 23. Uses formulae from Astronomical Almanac, 1984,
-and does the calculations in equatorial rectangular coordinates to avoid singularities
-at the celestial poles.
+Calculates necessary changes to ra and dec due to the nutation of the
+Earth's rotation axis, as described in Meeus, Chap 23. Uses formulae
+from Astronomical Almanac, 1984, and does the calculations in equatorial
+rectangular coordinates to avoid singularities at the celestial poles.
 
 ### Arguments ###
 
@@ -30,21 +52,49 @@ at the celestial poles.
 
 The 5-tuple `(d_ra, d_dec, eps, d_psi, d_eps)`:
 
-* `d_ra`: correction to right ascension due to nutation
-* `d_dec`: correction to declination due to nutation
-* `eps`: the obliquity of the ecliptic
+* `d_ra`: correction to right ascension due to nutation, in degrees
+* `d_dec`: correction to declination due to nutation, in degrees
+* `eps`: the true obliquity of the ecliptic
 * `d_psi`: nutation in the longitude of the ecliptic
 * `d_eps`: nutation in the obliquity of the ecliptic
 
 ### Example ###
 
-```julia
+Example 23a in Meeus: On 2028 Nov 13.19 TD the mean position of Theta
+Persei is 2h 46m 11.331s 49d 20' 54.54''. Determine the shift in
+position due to the Earth's nutation.
 
+```julia
+julia> jd = jdcnv(2028,11,13,4,56)
+2.4620887055555554e6
+
+julia> co_nutate(jd,ten(2,46,11.331)*15,ten(49,20,54.54))
+(0.006058053578186673, 0.002650870610381162, 0.40904016038217567,
+ 14.8593894278967, 2.7038090372351267)
 ```
 
 ### Notes ###
 
 Code of this function is based on IDL Astronomy User's Library.
 
-This function calls [nutate](@ref).
+This function calls [obliquity](@ref).
 """
+co_nutate(jd::Real, ra::Real, dec::Real) =
+    _co_nutate(promote(float(jd), float(ra), float(dec))...)
+
+function co_nutate(jd::AbstractVector{R}, ra::AbstractVector{R},
+                   dec::AbstractVector{R}) where {R<:Real}
+    @assert length(jd) == length(ra) == length(dec) "jd, ra and dec vectors
+                                                     should be of the same length"
+    typejd = float(R)
+    ra_out  = similar(jd,  typejd)
+    dec_out = similar(dec, typejd)
+    eps_out = similar(dec, typejd)
+    d_psi_out = similar(dec, typejd)
+    d_eps_out = similar(dec, typejd)
+    for i in eachindex(jd)
+        ra_out[i], dec_out[i],eps_out[i], d_psi_out[i], d_eps_out[i]  =
+        co_nutate(jd[i], ra[i], dec[i])
+    end
+    return ra_out, dec_out, eps_out, d_psi_out, d_eps_out
+end

--- a/src/co_nutate.jl
+++ b/src/co_nutate.jl
@@ -11,8 +11,8 @@ function _co_nutate(jd::T, ra::T, dec::T) where {T<:AbstractFloat}
     x2 = x - sec2rad(y * ce + z * ce) * d_psi
     y2 = y + sec2rad(x * ce * d_psi - z * d_eps)
     z2 = z + sec2rad(x * se * d_psi + y * d_eps)
-    r = sqrt(x2^2 + y2^2 + z2^2)
-    xyproj = sqrt(x2^2 + y2^2)
+    xyproj = hypot(x2, y2)
+    r = hypot(xyproj, z2)
     ra2 = atan2(y2, x2)
     dec2 = asin(z2/r)
     ra2 = rad2deg(ra2)

--- a/src/co_nutate.jl
+++ b/src/co_nutate.jl
@@ -1,0 +1,50 @@
+# This file is a part of AstroLib.jl. License is MIT "Expat".
+
+function _co_nutate{T<:AbstractFloat}(jd::T, ra::T, dec::T)
+    
+
+end
+
+"""
+    co_nutate()
+
+### Purpose ###
+
+Calculate changes in RA and Dec due to nutation of the
+Earth's rotation
+
+### Explanation ###
+
+Calculates necessary changes to ra and dec due to the nutation of the Earth's rotation
+axis, as described in Meeus, Chap 23. Uses formulae from Astronomical Almanac, 1984,
+and does the calculations in equatorial rectangular coordinates to avoid singularities
+at the celestial poles.
+
+### Arguments ###
+
+* `jd`: julian date, scalar or vector
+* `ra`: right ascension in degrees, scalar or vector
+* `dec`: declination in degrees, scalar or vector
+
+### Output ###
+
+The 5-tuple `(d_ra, d_dec, eps, d_psi, d_eps)`:
+
+* `d_ra`: correction to right ascension due to nutation
+* `d_dec`: correction to declination due to nutation
+* `eps`: the obliquity of the ecliptic
+* `d_psi`: nutation in the longitude of the ecliptic
+* `d_eps`: nutation in the obliquity of the ecliptic
+
+### Example ###
+
+```julia
+
+```
+
+### Notes ###
+
+Code of this function is based on IDL Astronomy User's Library.
+
+This function calls [nutate](@ref).
+"""

--- a/src/co_nutate.jl
+++ b/src/co_nutate.jl
@@ -1,10 +1,8 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 
 function _co_nutate(jd::T, ra::T, dec::T) where {T<:AbstractFloat}
-    t = (jd - J2000) / (JULIANYEAR*100)
     d_psi, d_eps = nutate(jd)
-    eps0 = @evalpoly t 84381.406 -46.836769 -0.0001831 0.0020034 -0.576e-6 -4.34e-8
-    eps = sec2rad(eps0 + d_eps)
+    eps = obliquity(jd)
     ce = cos(eps)
     se = sin(eps)
     x = cosd(ra) * cosd(dec)
@@ -77,16 +75,19 @@ julia> co_nutate(jd,ten(2,46,11.331)*15,ten(49,20,54.54))
 
 Code of this function is based on IDL Astronomy User's Library.
 
-This function calls [obliquity](@ref).
+The output of `d_ra` and `d_dec` in IDL AstroLib is in arcseconds,
+however it is in degrees here.
+
+This function calls [obliquity](@ref) and [nutate](@ref).
 """
 co_nutate(jd::Real, ra::Real, dec::Real) =
     _co_nutate(promote(float(jd), float(ra), float(dec))...)
 
-function co_nutate(jd::AbstractVector{R}, ra::AbstractVector{R},
-                   dec::AbstractVector{R}) where {R<:Real}
+function co_nutate(jd::AbstractVector{P}, ra::AbstractVector{Q},
+                   dec::AbstractVector{R}) where {P<:Real, Q<:Real, R<:Real}
     @assert length(jd) == length(ra) == length(dec) "jd, ra and dec vectors
                                                      should be of the same length"
-    typejd = float(R)
+    typejd = float(P)
     ra_out  = similar(jd,  typejd)
     dec_out = similar(dec, typejd)
     eps_out = similar(dec, typejd)

--- a/src/mean_obliquity.jl
+++ b/src/mean_obliquity.jl
@@ -1,16 +1,15 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 
 """
-    obliquity(jd) -> eps
+    mean_obliquity(jd) -> m_eps
 
 ### Purpose ###
 
-Return the true obliquity of the ecliptic for a given Julian date
+Return the mean obliquity of the ecliptic for a given Julian date
 
 ### Explanation ###
 
-The function is used by the [co_nutate](@ref) and [co_aberration](@ref)
-procedures.
+The function is used by the [co_nutate](@ref) procedure.
 
 ### Arguments ###
 
@@ -18,13 +17,13 @@ procedures.
 
 ### Output ###
 
-* `eps`: true obliquity of the ecliptic, in radians
+* `m_eps`: mean obliquity of the ecliptic, in radians
 
 ### Example ###
 
 ```julia
-julia> obliquity(jdcnv(1978,01,7,11, 01))
-0.39642074387876974
+julia> mean_obliquity(jdcnv(1978,01,7,11, 01))
+0.4091425159336512
 ```
 
 ### Notes ###
@@ -33,9 +32,8 @@ The algorithm used to find the mean obliquity(`eps0`) is mentioned in
 USNO Circular 179, but the canonical reference for the IAU adoption
 is apparently Hilton et al., 2006, Celest.Mech.Dyn.Astron. 94, 351. 2000
 """
-function obliquity(jd::Real)
+function mean_obliquity(jd::Real)
     t = (jd - J2000) / (JULIANYEAR * 100)
     eps0 = @evalpoly t 84381.406 -46.836769 -0.0001831 0.0020034 -0.576e-6 -4.34e-8
-    eps = sec2rad(eps0 + nutate(jd)[2])
-    return eps
+    return sec2rad(eps0)
 end

--- a/src/true_obliquity.jl
+++ b/src/true_obliquity.jl
@@ -1,0 +1,37 @@
+# This file is a part of AstroLib.jl. License is MIT "Expat".
+
+"""
+    true_obliquity(jd) -> t_eps
+
+### Purpose ###
+
+Return the true obliquity of the ecliptic for a given Julian date
+
+### Explanation ###
+
+The function is used by the [co_aberration](@ref) procedure.
+
+### Arguments ###
+
+* `jd`: julian date, scalar
+
+### Output ###
+
+* `t_eps`: true obliquity of the ecliptic, in radians
+
+### Example ###
+
+```julia
+julia> true_obliquity(jdcnv(1978,01,7,11, 01))
+0.4090953896211926
+```
+
+### Notes ###
+
+The function calls [mean_obliquity](@ref).
+"""
+function true_obliquity(jd::Real)
+    eps0 = mean_obliquity(jd)
+    t_eps = eps0 + sec2rad(nutate(jd)[2])
+    return t_eps
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,6 +22,9 @@ export calz_unred
 include("co_aberration.jl")
 export co_aberration
 
+include("co_nutate.jl")
+export co_nutate
+
 include("ct2lst.jl")
 export ct2lst
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -106,6 +106,9 @@ export mag2flux
 include("mag2geo.jl")
 export mag2geo
 
+include("mean_obliquity.jl")
+export mean_obliquity
+
 include("month_cnv.jl")
 export month_cnv
 
@@ -117,9 +120,6 @@ export mphase
 
 include("nutate.jl")
 export nutate
-
-include("obliquity.jl")
-export obliquity
 
 include("paczynski.jl")
 export paczynski
@@ -177,6 +177,9 @@ export ticpos
 
 include("tics.jl")
 export tics
+
+include("true_obliquity.jl")
+export true_obliquity
 
 include("trueanom.jl")
 export trueanom

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -443,6 +443,13 @@ let
     @test long ≈ 56.78
 end
 
+@testset "mean_obliquity" begin
+    @test mean_obliquity(AstroLib.J2000) ≈ 0.4090926006005829
+    @test mean_obliquity.(jdcnv.([DateTime(1916, 09, 22, 03, 39),
+                             DateTime(2063, 10, 13, 09)])) ≈
+        [0.4092816887615259, 0.40894777540460037]
+end
+
 # Test month_cnv
 @test month_cnv.([" januavv  ", "SEPPES ", " aUgUsT", "la"]) == [1, 9, 8, -1]
 @test month_cnv.([2, 12, 6], short=true, low=true) == ["feb", "dec", "jun"]
@@ -485,14 +492,6 @@ let
     long, obl = nutate([2457000, 2458000])
     @test long ≈ [ 4.327189321653877, -9.686089990639474]
     @test obl  ≈ [-9.507794266102866, -6.970768250588256]
-end
-
-# Test obliquity
-@testset "obliquity" begin
-    @test obliquity(AstroLib.J2000) ≈ 0.4090646078966446
-    @test obliquity.(jdcnv.([DateTime(2016, 08, 23, 03, 39, 06),
-                             DateTime(763, 09, 18, 12)])) ≈
-        [0.4090133706884892, 0.41188965892279295]
 end
 
 # Test paczynski
@@ -725,6 +724,14 @@ let
     ticsize, incr = tics(pi/3, pi/2, 60.0, 7.5, true)
     @test ticsize ≈ 14.085212463632736
     @test incr ≈ 0.5
+end
+
+# Test true_obliquity
+@testset "true_obliquity" begin
+    @test true_obliquity(AstroLib.J2000) ≈ 0.4090646078966446
+    @test true_obliquity.(jdcnv.([DateTime(2016, 08, 23, 03, 39, 06),
+                             DateTime(763, 09, 18, 12)])) ≈
+        [0.4090133706884892, 0.41188965892279295]
 end
 
 # Test kepler_solver

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -78,6 +78,25 @@ end
     @test bo[2] ≈ 2.9205843718089457
 end
 
+# Test co_nutate
+# The values used for the testset are from running the code. They are slightly
+# different from the output of the co_aberration routine of IDL AstroLib, as
+# the function here uses an updated method to find mean obliquity
+@testset "co_nutate" begin
+    an,bn,cn,dn,en = co_nutate([jdcnv(2028,11,13,4,56), jdcnv(2013, 4, 16)],[10, 160],[80,30])
+    @test an ≈ [0.00332316985077874, 0.0028100303682379035  ]
+    @test bn ≈ [0.0037962761358869557, -0.002223911512604815]
+    @test cn ≈ [0.40904016038217567, 0.4090340058477726     ]
+    @test dn ≈ [14.8593894278967, 12.102640377483143        ]
+    @test en ≈ [2.7038090372351267, -5.86229256359996       ]
+    ra_out, dec_out, eps_out, d_psi_out, d_eps_out = co_nutate(2.451545e6,325, 0)
+    @test ra_out ≈ -0.0035484441576727477
+    @test dec_out ≈ -0.00034017946720967174
+    @test eps_out ≈ 0.4090646078966446
+    @test d_psi_out ≈ -13.923152677481191
+    @test d_eps_out ≈ -5.773909654153591
+end
+
 # Test ct2lst
 @test ct2lst.(-76.72, -4, [DateTime(2008, 7, 30, 15, 53)]) ≈ [11.356505172312609]
 @test ct2lst.(9, [jdcnv(2015, 11, 24, 12, 21)]) ≈ [17.159574059885927]


### PR DESCRIPTION
Implements obliquity function. Unlike the IDL AstroLib routine, the output here for right ascension and declination is in degrees rather than arcseconds for more consistency (the same is done at [Astronomy Users Library](https://rdrr.io/cran/astrolibR/)).