### PR TITLE
Add hor2eq function

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -68,7 +68,6 @@ Missing in AstroLib.jl
 * `fm_unred`
 * `gal_flat`
 * `get_coords`
-* `hor2eq`
 * `imcontour`
 * `planet_coords`
 * `qdcb_grid`

--- a/docs/src/ref.md
+++ b/docs/src/ref.md
@@ -106,6 +106,7 @@ julia> AstroLib.planets["saturn"].mass
 [`hadec2altaz()`](@ref),
 [`helio_rv()`](@ref),
 [`helio()`](@ref),
+[`hor2eq()`](@ref),
 [`jprecess()`](@ref),
 [`mag2geo()`](@ref),
 [`mean_obliquity()`](@ref),

--- a/src/hor2eq.jl
+++ b/src/hor2eq.jl
@@ -1,9 +1,9 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 
-function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T, pressure::T,
-                 temperature::T, obsname::AbstractString, ws::Bool, B1950::Bool,
+function _hor2eq(alt::T, az::T, jd::T, ws::Bool, B1950::Bool,
                  precession::Bool, nutate::Bool, aberration::Bool,
-                 refract::Bool) where {T<:AbstractFloat}
+                 refract::Bool, lat::T, lon::T, altitude::T, pressure::T,
+                 temperature::T, obsname::AbstractString) where {T<:AbstractFloat}
 
     if obsname == ""
         # Using Pine Bluff Observatory values
@@ -15,9 +15,9 @@ function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T, pressure::T,
             lon = T(-89.865)
         end
     else
-        lat = T(observatories[obsname].latitude)
-        lon = one(T) * observatories[obsname].longitude
-        altitude = T(observatories[obsname].altitude)
+        lat = observatories[obsname].latitude
+        lon = observatories[obsname].longitude
+        altitude = observatories[obsname].altitude
     end
 
     if refract
@@ -33,6 +33,7 @@ function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T, pressure::T,
     last = 15 * ct2lst(lon, jd) + d_psi * cos(eps) / 3600
     ha, dec = altaz2hadec(alt_b, az, lat)
     ra = mod(last - ha, 360)
+    ha /= 15
     dra1, ddec1, eps, _, _ = co_nutate(jd, ra, dec)
     dra2, ddec2 = co_aberration(jd, ra, dec, eps)
 
@@ -46,19 +47,14 @@ function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T, pressure::T,
         dec -= ddec2 / 3600
     end
     j_now = (jd - J2000) / JULIANYEAR + 2000
-
     if precession
-
         if B1950
-            ra_o, dec_o = precess(ra, dec, j_now, 1950, FK4=true)
+            ra, dec = precess(ra, dec, j_now, 1950, FK4=true)
         else
-            ra_o, dec_o = precess(ra, dec, j_now, 2000)
+            ra, dec = precess(ra, dec, j_now, 2000)
         end
-    else
-        ra_o = ra
-        dec_o = dec
     end
-    return ra_o, dec_o, ha
+    return ra, dec, ha
 end
 """
 
@@ -78,6 +74,19 @@ It performs precession, nutation, aberration, and refraction corrections.
 * `alt`: altitude of horizon coords, in degrees
 * `az`: azimuth angle measured East from North (unless ws is `true`), in degrees
 * `jd`: julian date
+* `ws` (optional boolean): set this to `true` to get the azimuth measured
+  westward from south
+* `B1950` (optional boolean): Set this to `true` if the ra and dec
+  are specified in B1950 (FK4 coordinates) instead of J2000 (FK5). This is `false` by
+  default
+* `precession` (optional boolean): set this to `false` for no precession,
+  `true` by default
+* `nutate` (optional boolean): set this to `false` for no nutation,
+  `true` by default
+* `aberration` (optional boolean): set this to `false` for no aberration
+  correction, `true` by default
+* `refract` (optional boolean): set this to `false` for no refraction
+  correction, `true` by default
 * `lat` (optional keyword): north geodetic latitude of location, in degrees. Default
   is NaN
 * `lon` (optional keyword): AST longitude of location, in degrees. You can specify west
@@ -91,18 +100,6 @@ It performs precession, nutation, aberration, and refraction corrections.
 * `obsname` (optional keyword): set this to a valid observatory name to
   be used by the observatory type in [types](@ref), which will return
   the latitude and longitude to be used by this program. Default is NaN.
-* `ws` (optional boolean keyword): set this to `true` to get the azimuth measured
-  westward from south
-* `B1950` (optional boolean keyword): Set this to `true` if the ra and dec
-  are specified in B1950 (FK4 coordinates) instead of J2000 (FK5)
-* `precession` (optional boolean keyword): set this to `false` for no precession,
-  `true` by default
-* `nutate` (optional boolean keyword): set this to `false` for no nutation,
-  `true` by default
-* `aberration` (optional boolean keyword): set this to `false` for no aberration
-  correction, `true` by default
-* `refract` (optional boolean keyword): set this to `false` for no refraction
-  correction, `true` by default
 
 ### Output ###
 
@@ -112,18 +109,29 @@ It performs precession, nutation, aberration, and refraction corrections.
 
 ### Example ###
 
-```jldoctest
+You are at Kitt Peak National Observatory, looking at a star at azimuth
+angle 264d 55m 06s and elevation 37d 54m 41s (in the visible). Today is Dec 25, 2041
+and the local time is 10 PM precisely. What is the right ascension and declination
+(J2000) of the star you're looking at? The temperature here is about 0 Celsius,
+and the pressure is 781 millibars. The Julian date for this time is 2466879.7083333
 
+```jldoctest
+julia> ra_o, dec_o = hor2eq(ten(37,54,41), ten(264,55,06), 2466879.7083333, obsname="kpno",
+                            pressure = 711, temperature = 273)
+(3.3222851503189124, 15.190605763758745, 3.640795457403172)
+
+julia> adstring(ra_o, dec_o)
+" 00 13 17.3  +15 11 26"
 ```
 
 ### Notes ###
 
 Code of this function is based on IDL Astronomy User's Library.
 """
-hor2eq(alt::Real, az::Real, jd::Real; lat::Real=NaN, lon::Real=NaN, altitude::Real=0,
-       pressure::Real=NaN, temperature::Real=NaN, obsname::AbstractString="",
-       ws::Bool=false, B1950::Bool=false, precession::Bool=true, nutate::Bool=true,
-       aberration::Bool=true, refract::Bool=true) =
-           _hor2eq(promote(float(alt), float(az), float(jd), float(lat), float(lon),
-                   float(altitude), float(temperature), float(pressure))..., obsname,
-                   ws, B1950, precession, nutate, aberration, refract)
+hor2eq(alt::Real, az::Real, jd::Real, ws::Bool=false, B1950::Bool=false,
+       precession::Bool=true, nutate::Bool=true, aberration::Bool=true,
+       refract::Bool=true ; lat::Real=NaN, lon::Real=NaN, altitude::Real=0,
+       pressure::Real=NaN, temperature::Real=NaN, obsname::AbstractString="",) =
+           _hor2eq(float(alt), float(az), float(jd), ws, B1950, precession,
+                   nutate, aberration, refract, promote(float(lat), float(lon),
+                   float(altitude), float(temperature), float(pressure))..., obsname)

--- a/src/hor2eq.jl
+++ b/src/hor2eq.jl
@@ -1,10 +1,11 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 
-function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, ws::Bool, obsname::T, FK4::Bool,
-                 altitude::T, precess::Bool, nutate::Bool, abberation::Bool,
+function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T, pressure::T,
+                 temperature::T, obsname::AbstractString, ws::Bool, B1950::Bool,
+                 precess::Bool, nutate::Bool, aberration::Bool,
                  refract::Bool) where {T<:AbstractFloat}
 
-    if isnan(obsname)
+    if obsname == ""
         # Using Pine Bluff Observatory values
         if isnan(lat)
             lat = T(43.0783)
@@ -18,21 +19,47 @@ function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, ws::Bool, obsname::T, FK4
         lon = -one(T) * observatories[obsname].longitude
         altitude = T(observatories[obsname].altitude)
     end
-    
+
     if refract
-        az_b = co_refract(alt, altitude)
+        alt_b = co_refract(alt, altitude, pressure, temperature)
     else
-        az_b = az
+        alt_b = az
     end
 
     if ws
-        az_b -= 180
+        az -= 180
     end
     dra1, ddec1, eps, d_psi, _ = co_nutate(jd, 45, 45)
-    last = 15 * ct2lst(lon, jd) + d_psi * cos(eps) / 3600
-    
-end
+    last = 15 * ct2lst(lon, jd) + d_psi * cos(eps)
+    ha, dec = altaz2hadec(alt_b, az, lat)
+    ra = mod(last - ha, 360)
+    dra1, ddec1, eps, _, _ = co_nutate(jd, ra, dec)
+    dra2, ddec2 = co_aberration(jd, ra, dec, eps)
 
+    if nutate
+       ra -= dra1
+       dec -= ddec1
+    end
+
+    if aberration
+        ra -= dra2 / 3600
+        dec -= ddec2 / 3600
+    end
+    j_now = (jd - J2000) / JULIANYEAR + 2000
+
+    if precess
+
+        if B1950
+            ra_o, dec_o = AstroLib.precess(ra, dec, j_now, 1950, FK4=true)
+        else
+            ra_o, dec_o = AstroLib.precess(ra, dec, j_now, 2000)
+        end
+    else
+        ra_o = ra
+        dec_o = dec
+    end
+    return ra_o, dec_o, ha
+end
 """
 
 
@@ -51,25 +78,31 @@ It performs precession, nutation, aberration, and refraction corrections.
 * `alt`: altitude of horizon coords, in degrees
 * `az`: azimuth angle measured East from North (unless ws is `true`), in degrees
 * `jd`: julian date
-* `lat`(optional keyword): north geodetic latitude of location, in degrees. Default
+* `lat` (optional keyword): north geodetic latitude of location, in degrees. Default
   is NaN
-* `lon`(optional keyword): AST longitude of location, in degrees. You can specify west
-  longitude with a negative sign. Dafualt is NaN.
-* `ws` (optional boolean keyword): set this to `true` to get the azimuth measured
-  westward from south
-* `obsname`(optional keyword): set this to a valid observatory name to
+* `lon` (optional keyword): AST longitude of location, in degrees. You can specify west
+  longitude with a negative sign. Dafault is NaN.
+* `altitude` (optional keyword): the altitude of the observing location, in meters.
+  It it zero by default
+* `pressure` (optional keyword): the pressure at the observing location, in millibars.
+  Default is NaN
+* `temperature` (optional keyword): the temperature at the observing location, in Kelvins.
+  Default is NaN
+* `obsname` (optional keyword): set this to a valid observatory name to
   be used by the observatory type in [types](@ref), which will return
   the latitude and longitude to be used by this program. Default is NaN.
-* `FK4`(optional boolean keyword): Set this to `true` if the ra and dec
+* `ws` (optional boolean keyword): set this to `true` to get the azimuth measured
+  westward from south
+* `B1950` (optional boolean keyword): Set this to `true` if the ra and dec
   are specified in B1950 (FK4 coordinates) instead of J2000 (FK5)
-* `altitude`(optional keyword): the altitude of the observing location, in meters.
-  It it zero by default
-* `precess`(optional keyword): set this to `false` for no precession, `true` by default
-* `nutate`(optional keyword): set this to `false` for no nutation, `true` by default
-* `abberation`(optional keyword): set this to `false` for no abberation correction,
+* `precess` (optional boolean keyword): set this to `false` for no precession,
   `true` by default
-* `refract`(optional keyword): set this to `false` for no refraction correction,
+* `nutate` (optional boolean keyword): set this to `false` for no nutation,
   `true` by default
+* `aberration` (optional boolean keyword): set this to `false` for no aberration
+  correction, `true` by default
+* `refract` (optional boolean keyword): set this to `false` for no refraction
+  correction, `true` by default
 
 ### Output ###
 
@@ -87,3 +120,10 @@ It performs precession, nutation, aberration, and refraction corrections.
 
 Code of this function is based on IDL Astronomy User's Library.
 """
+hor2eq(alt::Real, az::Real, jd::Real; lat::Real=NaN, lon::Real=NaN, altitude::Real=0,
+       pressure::Real=NaN, temperature::Real=NaN, obsname::AbstractString="",
+       ws::Bool=false, B1950::Bool=false, precess::Bool=true, nutate::Bool=true,
+       aberration::Bool=true, refract::Bool=true) =
+           _hor2eq(promote(float(alt), float(az), float(jd), float(lat), float(lon),
+                   float(altitude), float(temperature), float(pressure))..., obsname,
+                   ws, B1950, precess, nutate, aberration, refract)

--- a/src/hor2eq.jl
+++ b/src/hor2eq.jl
@@ -2,7 +2,7 @@
 
 function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T, pressure::T,
                  temperature::T, obsname::AbstractString, ws::Bool, B1950::Bool,
-                 precess::Bool, nutate::Bool, aberration::Bool,
+                 precession::Bool, nutate::Bool, aberration::Bool,
                  refract::Bool) where {T<:AbstractFloat}
 
     if obsname == ""
@@ -47,12 +47,12 @@ function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T, pressure::T,
     end
     j_now = (jd - J2000) / JULIANYEAR + 2000
 
-    if precess
+    if precession
 
         if B1950
-            ra_o, dec_o = AstroLib.precess(ra, dec, j_now, 1950, FK4=true)
+            ra_o, dec_o = precess(ra, dec, j_now, 1950, FK4=true)
         else
-            ra_o, dec_o = AstroLib.precess(ra, dec, j_now, 2000)
+            ra_o, dec_o = precess(ra, dec, j_now, 2000)
         end
     else
         ra_o = ra
@@ -95,7 +95,7 @@ It performs precession, nutation, aberration, and refraction corrections.
   westward from south
 * `B1950` (optional boolean keyword): Set this to `true` if the ra and dec
   are specified in B1950 (FK4 coordinates) instead of J2000 (FK5)
-* `precess` (optional boolean keyword): set this to `false` for no precession,
+* `precession` (optional boolean keyword): set this to `false` for no precession,
   `true` by default
 * `nutate` (optional boolean keyword): set this to `false` for no nutation,
   `true` by default
@@ -122,8 +122,8 @@ Code of this function is based on IDL Astronomy User's Library.
 """
 hor2eq(alt::Real, az::Real, jd::Real; lat::Real=NaN, lon::Real=NaN, altitude::Real=0,
        pressure::Real=NaN, temperature::Real=NaN, obsname::AbstractString="",
-       ws::Bool=false, B1950::Bool=false, precess::Bool=true, nutate::Bool=true,
+       ws::Bool=false, B1950::Bool=false, precession::Bool=true, nutate::Bool=true,
        aberration::Bool=true, refract::Bool=true) =
            _hor2eq(promote(float(alt), float(az), float(jd), float(lat), float(lon),
                    float(altitude), float(temperature), float(pressure))..., obsname,
-                   ws, B1950, precess, nutate, aberration, refract)
+                   ws, B1950, precession, nutate, aberration, refract)

--- a/src/hor2eq.jl
+++ b/src/hor2eq.jl
@@ -1,0 +1,89 @@
+# This file is a part of AstroLib.jl. License is MIT "Expat".
+
+function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, ws::Bool, obsname::T, FK4::Bool,
+                 altitude::T, precess::Bool, nutate::Bool, abberation::Bool,
+                 refract::Bool) where {T<:AbstractFloat}
+
+    if isnan(obsname)
+        # Using Pine Bluff Observatory values
+        if isnan(lat)
+            lat = T(43.0783)
+        end
+
+        if isnan(lon)
+            lon = T(-89.865)
+        end
+    else
+        lat = T(observatories[obsname].latitude)
+        lon = -one(T) * observatories[obsname].longitude
+        altitude = T(observatories[obsname].altitude)
+    end
+    
+    if refract
+        az_b = co_refract(alt, altitude)
+    else
+        az_b = az
+    end
+
+    if ws
+        az_b -= 180
+    end
+    dra1, ddec1, eps, d_psi, _ = co_nutate(jd, 45, 45)
+    last = 15 * ct2lst(lon, jd) + d_psi * cos(eps) / 3600
+    
+end
+
+"""
+
+
+### Purpose ###
+
+Converts local horizon coordinates (alt-az) to equatorial (ra-dec) coordinates.
+
+### Explanation ###
+
+This is a function to calculate equatorial (ra,dec) coordinates from
+horizon (alt,az) coords. It is accurate to about 1 arcsecond or better.
+It performs precession, nutation, aberration, and refraction corrections.
+
+### Arguments ###
+
+* `alt`: altitude of horizon coords, in degrees
+* `az`: azimuth angle measured East from North (unless ws is `true`), in degrees
+* `jd`: julian date
+* `lat`(optional keyword): north geodetic latitude of location, in degrees. Default
+  is NaN
+* `lon`(optional keyword): AST longitude of location, in degrees. You can specify west
+  longitude with a negative sign. Dafualt is NaN.
+* `ws` (optional boolean keyword): set this to `true` to get the azimuth measured
+  westward from south
+* `obsname`(optional keyword): set this to a valid observatory name to
+  be used by the observatory type in [types](@ref), which will return
+  the latitude and longitude to be used by this program. Default is NaN.
+* `FK4`(optional boolean keyword): Set this to `true` if the ra and dec
+  are specified in B1950 (FK4 coordinates) instead of J2000 (FK5)
+* `altitude`(optional keyword): the altitude of the observing location, in meters.
+  It it zero by default
+* `precess`(optional keyword): set this to `false` for no precession, `true` by default
+* `nutate`(optional keyword): set this to `false` for no nutation, `true` by default
+* `abberation`(optional keyword): set this to `false` for no abberation correction,
+  `true` by default
+* `refract`(optional keyword): set this to `false` for no refraction correction,
+  `true` by default
+
+### Output ###
+
+* `ra`: right ascension of object, in degrees (FK5)
+* `dec`: declination of the object, in degrees (FK5)
+* `ha`: hour angle, in degrees
+
+### Example ###
+
+```jldoctest
+
+```
+
+### Notes ###
+
+Code of this function is based on IDL Astronomy User's Library.
+"""

--- a/src/hor2eq.jl
+++ b/src/hor2eq.jl
@@ -15,15 +15,13 @@ function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T,
             lon = T(-89.865)
         end
     else
-        lat = observatories[obsname].latitude
-        lon = observatories[obsname].longitude
-        altitude = observatories[obsname].altitude
+        lat = T(observatories[obsname].latitude)
+        lon = T(observatories[obsname].longitude)
+        altitude = T(observatories[obsname].altitude)
     end
 
     if refract
-        alt_b = co_refract(alt, altitude, pressure, temperature)
-    else
-        alt_b = alt
+        alt = co_refract(alt, altitude, pressure, temperature)
     end
 
     if ws
@@ -31,9 +29,8 @@ function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T,
     end
     _, _, eps, d_psi = co_nutate(jd, 45, 45)
     last = 15 * ct2lst(lon, jd) + d_psi * cos(eps) / 3600
-    ha, dec = altaz2hadec(alt_b, az, lat)
+    ha, dec = altaz2hadec(alt, az, lat)
     ra = mod(last - ha, 360)
-    ha /= 15
     dra1, ddec1, eps = co_nutate(jd, ra, dec)
 
     if nutate
@@ -111,7 +108,7 @@ It performs precession, nutation, aberration, and refraction corrections.
 
 * `ra`: right ascension of object, in degrees (FK5)
 * `dec`: declination of the object, in degrees (FK5)
-* `ha`: hour angle, in hours
+* `ha`: hour angle, in degrees
 
 ### Example ###
 
@@ -124,10 +121,10 @@ and the pressure is 781 millibars. The Julian date for this time is 2466879.7083
 ```jldoctest
 julia> ra_o, dec_o = hor2eq(ten(37,54,41), ten(264,55,06), 2466879.7083333,
                             obsname="kpno", pressure = 711, temperature = 273)
-(3.32228485671625, 15.19060567248328, 3.640795457403172)
+(3.32228485671625, 15.19060567248328, 54.61193186104758)
 
 julia> adstring(ra_o, dec_o)
-" 00 13 17.3  +15 11 26
+" 00 13 17.3  +15 11 26"
 ```
 
 ### Notes ###
@@ -141,3 +138,5 @@ hor2eq(alt::Real, az::Real, jd::Real; ws::Bool=false, B1950::Bool=false,
            _hor2eq(promote(float(alt), float(az), float(jd), float(lat), float(lon),
                    float(altitude), float(temperature), float(pressure))..., ws, B1950,
                    precession, nutate, aberration, refract, obsname)
+# TODO: Make hor2eq type-stable, which it isn't currently because of keyword arguments
+# Note that the inner function `_hor2eq` is type stable

--- a/src/hor2eq.jl
+++ b/src/hor2eq.jl
@@ -16,21 +16,21 @@ function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T, pressure::T,
         end
     else
         lat = T(observatories[obsname].latitude)
-        lon = -one(T) * observatories[obsname].longitude
+        lon = one(T) * observatories[obsname].longitude
         altitude = T(observatories[obsname].altitude)
     end
 
     if refract
         alt_b = co_refract(alt, altitude, pressure, temperature)
     else
-        alt_b = az
+        alt_b = alt
     end
 
     if ws
         az -= 180
     end
     dra1, ddec1, eps, d_psi, _ = co_nutate(jd, 45, 45)
-    last = 15 * ct2lst(lon, jd) + d_psi * cos(eps)
+    last = 15 * ct2lst(lon, jd) + d_psi * cos(eps) / 3600
     ha, dec = altaz2hadec(alt_b, az, lat)
     ra = mod(last - ha, 360)
     dra1, ddec1, eps, _, _ = co_nutate(jd, ra, dec)

--- a/src/hor2eq.jl
+++ b/src/hor2eq.jl
@@ -74,18 +74,18 @@ It performs precession, nutation, aberration, and refraction corrections.
 * `alt`: altitude of horizon coords, in degrees
 * `az`: azimuth angle measured East from North (unless ws is `true`), in degrees
 * `jd`: julian date
-* `ws` (optional boolean): set this to `true` to get the azimuth measured
+* `ws` (optional boolean keyword): set this to `true` to get the azimuth measured
   westward from south
-* `B1950` (optional boolean): Set this to `true` if the ra and dec
+* `B1950` (optional boolean keyword): Set this to `true` if the ra and dec
   are specified in B1950 (FK4 coordinates) instead of J2000 (FK5). This is `false` by
   default
-* `precession` (optional boolean): set this to `false` for no precession,
+* `precession` (optional boolean keyword): set this to `false` for no precession,
   `true` by default
-* `nutate` (optional boolean): set this to `false` for no nutation,
+* `nutate` (optional boolean keyword): set this to `false` for no nutation,
   `true` by default
-* `aberration` (optional boolean): set this to `false` for no aberration
+* `aberration` (optional boolean keyword): set this to `false` for no aberration
   correction, `true` by default
-* `refract` (optional boolean): set this to `false` for no refraction
+* `refract` (optional boolean keyword: set this to `false` for no refraction
   correction, `true` by default
 * `lat` (optional keyword): north geodetic latitude of location, in degrees. Default
   is NaN
@@ -128,9 +128,9 @@ julia> adstring(ra_o, dec_o)
 
 Code of this function is based on IDL Astronomy User's Library.
 """
-hor2eq(alt::Real, az::Real, jd::Real, ws::Bool=false, B1950::Bool=false,
+hor2eq(alt::Real, az::Real, jd::Real; ws::Bool=false, B1950::Bool=false,
        precession::Bool=true, nutate::Bool=true, aberration::Bool=true,
-       refract::Bool=true ; lat::Real=NaN, lon::Real=NaN, altitude::Real=0,
+       refract::Bool=true, lat::Real=NaN, lon::Real=NaN, altitude::Real=0,
        pressure::Real=NaN, temperature::Real=NaN, obsname::AbstractString="",) =
            _hor2eq(float(alt), float(az), float(jd), ws, B1950, precession,
                    nutate, aberration, refract, promote(float(lat), float(lon),

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,6 +85,9 @@ export helio_rv
 include("helio.jl")
 export helio
 
+include("hor2eq.jl")
+export hor2eq
+
 include("imf.jl")
 export imf
 

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -365,7 +365,7 @@ end
     @test ha_o ≈ 23.954057756664426
     ra_o, dec_o, ha_o = hor2eq(ten(37,54,41), ten(264,55,06), 2466879.7083333,
                                obsname="kpno", pressure = 711, temperature = 273)
-    @test ra_o ≈ 3.3222851503189124
+    @test ra_o ≈ 3.32228485671625
     @test dec_o ≈ 15.190605763758745
     @test ha_o ≈ 3.640795457403172
 end

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -346,6 +346,28 @@ end
     @test hlat_out[1] ≈ -0.6845757329085267
 end
 
+# Test hor2eq
+# The values used for the testset are from running the code. However they have been
+# correlated with the output from hor2eq routine of IDL AstroLib, with
+# differences only in the least significant digits.
+@testset "hor2eq" begin
+    ra_o, dec_o, ha_o = hor2eq(43.6879, 56.684, AstroLib.J2000)
+    @test ra_o ≈ 259.51843877394714
+    @test dec_o ≈ 49.62331048847169
+    @test ha_o ≈ 19.40545272279752
+    ra_o, dec_o, ha_o = hor2eq(1.345, 359.43, 2e6, true, true, false, false, false, false,
+                               lat = 54.435, lon = -34.78, altitude = 1000.34,
+                               pressure = 500.345, temperature = 293.343)
+    @test ra_o ≈ 142.2933457820434
+    @test dec_o ≈ -34.218006262991786
+    @test ha_o ≈ 23.954057756664426
+    ra_o, dec_o, ha_o = hor2eq(ten(37,54,41), ten(264,55,06), 2466879.7083333,
+                               obsname="kpno", pressure = 711, temperature = 273)
+    @test ra_o ≈ 3.3222851503189124
+    @test dec_o ≈ 15.190605763758745
+    @test ha_o ≈ 3.640795457403172
+end
+
 # Test imf
 # The values used for the testset are from running the code. However they have been
 # correlated with the output from imf routine of IDL AstroLib, with

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -351,13 +351,15 @@ end
 # correlated with the output from hor2eq routine of IDL AstroLib, with
 # differences only in the least significant digits.
 @testset "hor2eq" begin
-    ra_o, dec_o, ha_o = hor2eq(43.6879, 56.684, AstroLib.J2000)
-    @test ra_o ≈ 259.51843877394714
-    @test dec_o ≈ 49.62331048847169
+    ra_o, dec_o, ha_o = hor2eq(43.6879, 56.684, AstroLib.J2000, B1950=true)
+    @test ra_o ≈ 259.20005705918317
+    @test dec_o ≈ 49.674706171288655
     @test ha_o ≈ 19.40545272279752
-    ra_o, dec_o, ha_o = hor2eq(1.345, 359.43, 2e6, true, true, false, false, false, false,
-                               lat = 54.435, lon = -34.78, altitude = 1000.34,
-                               pressure = 500.345, temperature = 293.343)
+    ra_o, dec_o, ha_o = hor2eq(1.345, 359.43, 2e6, ws=true, B1950=true,
+                               precession = false, nutate=false, aberration=false,
+                               refract=false, lat = 54.435, lon = -34.78,
+                               altitude = 1000.34, pressure = 500.345,
+                               temperature = 293.343)
     @test ra_o ≈ 142.2933457820434
     @test dec_o ≈ -34.218006262991786
     @test ha_o ≈ 23.954057756664426

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -354,7 +354,7 @@ end
     ra_o, dec_o, ha_o = hor2eq(43.6879, 56.684, AstroLib.J2000, B1950=true)
     @test ra_o ≈ 259.20005705918317
     @test dec_o ≈ 49.674706171288655
-    @test ha_o ≈ 19.40545272279752
+    @test ha_o ≈ 291.0817908419628
     ra_o, dec_o, ha_o = hor2eq(1.345, 359.43, 2e6, ws=true, B1950=true,
                                precession = false, nutate=false, aberration=false,
                                refract=false, lat = 54.435, lon = -34.78,
@@ -362,12 +362,18 @@ end
                                temperature = 293.343)
     @test ra_o ≈ 142.2933457820434
     @test dec_o ≈ -34.218006262991786
-    @test ha_o ≈ 23.954057756664426
+    @test ha_o ≈ 359.3108663499664
     ra_o, dec_o, ha_o = hor2eq(ten(37,54,41), ten(264,55,06), 2466879.7083333,
                                obsname="kpno", pressure = 711, temperature = 273)
     @test ra_o ≈ 3.32228485671625
     @test dec_o ≈ 15.190605763758745
-    @test ha_o ≈ 3.640795457403172
+    @test ha_o ≈ 54.61193186104758
+    ra_o, dec_o, ha_o = @inferred(AstroLib._hor2eq(43.6879, 56.684, Float64(AstroLib.J2000),
+                                          NaN, NaN, 0.0, NaN, NaN, false, false, true,
+                                          true, true, true, ""))
+    @test ra_o ≈ 259.5184384071214
+    @test dec_o ≈ 49.623310468816314
+    @test ha_o ≈ 291.0817908419628
 end
 
 # Test imf


### PR DESCRIPTION
The function was a bit tricky to do (the `Real` type keyword arguments, if placed before the `Bool` type keyword arguments lead to type-instability).

Additionally, this is an important function because of the many functions it is dependent upon (good chance of this function's tests breaking if some other function is modified in the future).