### PR TITLE
Get rid of cirrange

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,8 @@ Already Present in Julia
 ------------------------
 
 * `asinh`
+* `cirrange`.  It is equivalent to `mod(x, 360)`, or to `mod2pi(x)` for the `[0,
+  2pi)` range.
 * `minmax`.  It is called `extrema` in Julia.
 * `permute`.  It is called `randperm` in Julia.
 * `to_hex`.  It is called `hex` in Julia.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -73,6 +73,9 @@ This is not the only effort to bundle astronomical functions written in Julia la
 Because of this, some of IDL AstroLib’s utilities are not provided in `AstroLib.jl` as they are already present in other Julia packages. Here is a list of such utilities:
 
 -   `aper`, see [AperturePhotometry.jl](https://github.com/kbarbary/AperturePhotometry.jl) package
+-   `asinh`, already present in Julia with the same name
+-   `cirrange`, it is equivalent to `mod(x, 360)`.  To restrict a number to the
+    range `[0, 2pi)` use `mod2pi(x)`
 -   `cosmo_param`, see [Cosmology.jl](https://github.com/JuliaAstro/Cosmology.jl) package
 -   `galage`, see [Cosmology.jl](https://github.com/JuliaAstro/Cosmology.jl) package
 -   `glactc_pm`, see [SkyCoords.jl](https://github.com/kbarbary/SkyCoords.jl) package

--- a/docs/src/ref.md
+++ b/docs/src/ref.md
@@ -147,7 +147,6 @@ julia> AstroLib.planets["saturn"].mass
 
 [`airtovac()`](@ref),
 [`calz_unred()`](@ref),
-[`cirrange()`](@ref),
 [`deredd()`](@ref),
 [`flux2mag()`](@ref),
 [`gal_uvw()`](@ref),

--- a/src/bprecess.jl
+++ b/src/bprecess.jl
@@ -64,7 +64,7 @@ function _bprecess{T<:AbstractFloat}(ra::T, dec::T, parallax::T,
     #     parallax = parallax / rmag
     # end
     if ra1950 < 0
-        ra1950 += 2pi
+        ra1950 += 2 * T(pi)
     end
     ra1950  = rad2deg(ra1950)
     dec1950 = rad2deg(dec1950)

--- a/src/ct2lst.jl
+++ b/src/ct2lst.jl
@@ -6,7 +6,7 @@ function ct2lst{T<:AbstractFloat}(long::T, jd::T)
     t  = t0 / JULIANCENTURY
     # Compute GST in seconds.
     θ = ct2lst_c[1] + (ct2lst_c[2]*t0) + t*t*(ct2lst_c[3] - t / ct2lst_c[4])
-    return cirrange((θ + long)/15, 24)
+    return mod((θ + long)/15, 24)
 end
 
 """

--- a/src/eci2geo.jl
+++ b/src/eci2geo.jl
@@ -6,7 +6,7 @@ function _eci2geo{T<:AbstractFloat}(x::T, y::T, z::T, jd::T)
     theta = atan2(y, x) # Azimuth.
     gst   = ct2lst(zero(T), jd)
     sid_angle = gst*pi/12 # Sidereal angle.
-    long  = cirrange(rad2deg(theta - sid_angle)) # Longitude.
+    long  = mod(rad2deg(theta - sid_angle), 360) # Longitude.
     r     = hypot(x, y)
     lat   = atan2(z, r) # Latitude.
     alt   = r/cos(lat) - Re # Altitude.

--- a/src/hadec2altaz.jl
+++ b/src/hadec2altaz.jl
@@ -15,11 +15,11 @@ function _hadec2altaz{T<:AbstractFloat}(ha::T, dec::T, lat::T, ws::Bool)
     r = hypot(x, y)
 
     # Now get altitude, azimuth
-    az  = cirrange(rad2deg(atan2(y, x)))
+    az  = mod(rad2deg(atan2(y, x)), 360)
     alt = rad2deg(atan2(z, r))
     # Convert azimuth to West from South, if desired
     if ws
-        az = cirrange(az + 180.0)
+        az = mod(az + 180, 360)
     end
     return alt, az
 end

--- a/src/helio.jl
+++ b/src/helio.jl
@@ -33,7 +33,7 @@ function _helio(jd::T, num::Integer, radians::Bool) where {T<:AbstractFloat}
     m = mlong - plong
     nu = trueanom(kepler_solver(m, eccen), eccen)
     hrad = a * (1 - eccen * cos(e))
-    hlong = cirrange(nu + plong, 2 * pi)
+    hlong = mod2pi(nu + plong)
     hlat = asin(sin(hlong - along) * sin(inc))
     if !radians
         return hrad, rad2deg(hlong), rad2deg(hlat)

--- a/src/jprecess.jl
+++ b/src/jprecess.jl
@@ -65,7 +65,7 @@ function _jprecess{T<:AbstractFloat}(ra::T, dec::T, parallax::T,
     #     parallax = parallax / rmag
     # end
     if ra2000 < 0
-        ra2000 += 2pi
+        ra2000 += 2 * T(pi)
     end
     ra2000  = rad2deg(ra2000)
     dec2000 = rad2deg(dec2000)

--- a/src/kepler_solver.jl
+++ b/src/kepler_solver.jl
@@ -98,13 +98,13 @@ julia> E = kepler_solver(8pi/3, ecc)
 
 (2) Plot the eccentric anomaly as a function of mean anomaly for eccentricity
 \$e = 0\$, \$0.5\$, \$0.9\$.  Recall that `kepler_solver` gives \$E \\in [-\\pi,
-\\pi]\$, use `cirrange` to have it in \$[0, 2\\pi]\$.  Use
+\\pi]\$, use `mod2pi` to have it in \$[0, 2\\pi]\$.  Use
 [PyPlot.jl](https://github.com/JuliaPlots/Plots.jl/) for plotting.
 
 ```julia
-using PyPlot
+using AstroLib, PyPlot
 M = linspace(0, 2pi, 1001)[1:end-1];
-for ecc in (0, 0.5, 0.9); plot(M, cirrange.(kepler_solver.(M, ecc), 2pi)); end
+for ecc in (0, 0.5, 0.9); plot(M, mod2pi.(kepler_solver.(M, ecc))); end
 ```
 
 ### Notes ###

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -1,9 +1,6 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 # Copyright (C) 2016 Mosè Giordano.
 
-include("cirrange.jl")
-export cirrange
-
 include("ordinal.jl")
 export ordinal
 

--- a/src/moonpos.jl
+++ b/src/moonpos.jl
@@ -59,22 +59,22 @@ function _moonpos{T<:AbstractFloat}(jd::T, radians::Bool)
     # Number of Julian centuries since 2000-01-01T12:00:00
     t = (jd - J2000) / JULIANCENTURY
     # Mean longitude of the moon referred to mean equinox of the date
-    Lprimed = cirrange(@evalpoly(t, 218.3164477, 481267.88123421,
-                                 -0.0015786, inv(538841), -inv(6.5194e7)))
+    Lprimed = mod(@evalpoly(t, 218.3164477, 481267.88123421,
+                            -0.0015786, inv(538841), -inv(6.5194e7)), 360)
     Lprime = deg2rad(Lprimed)
     # Mean elongation of the Moon
-    d = deg2rad(cirrange(@evalpoly(t, 297.8501921, 445267.1114034, -0.0018819,
-                                   inv(545868), -inv(1.13065e8))))
+    d = deg2rad(mod(@evalpoly(t, 297.8501921, 445267.1114034, -0.0018819,
+                              inv(545868), -inv(1.13065e8)), 360))
     # Sun's mean anomaly
-    M = deg2rad(cirrange(@evalpoly(t, 357.5291092, 35999.0502909, -0.0001536,
-                                   inv(2.449e7))))
+    M = deg2rad(mod(@evalpoly(t, 357.5291092, 35999.0502909, -0.0001536,
+                              inv(2.449e7)), 360))
     # Moon's mean anomaly
-    Mprime = deg2rad(cirrange(@evalpoly(t, 134.9633964, 477198.8675055,
-                                        0.0087414, inv(6.9699e4),
-                                        -inv(1.4712e7))))
+    Mprime = deg2rad(mod(@evalpoly(t, 134.9633964, 477198.8675055,
+                                   0.0087414, inv(6.9699e4),
+                                   -inv(1.4712e7)), 360))
     # Moon's argument of latitude
-    F = deg2rad(cirrange(@evalpoly(t, 93.2720950, 483202.0175233, -0.0036539,
-                                   -inv(3.526e7), inv(8.6331e8))))
+    F = deg2rad(mod(@evalpoly(t, 93.2720950, 483202.0175233, -0.0036539,
+                              -inv(3.526e7), inv(8.6331e8)), 360))
     # Eccentricity of Earth's orbit around the Sun
     E = @evalpoly t 1 -0.002516 -7.4e-6
     E2 = E*E
@@ -110,14 +110,14 @@ function _moonpos{T<:AbstractFloat}(jd::T, radians::Bool)
     arg = moon_d_lat*d + moon_M_lat*M + moon_Mprime_lat*Mprime + moon_F_lat*F
     geolat = (sum(sinlat.*sin.(arg)) + sumb_add)/1000000
     nlong, elong = nutate(jd)
-    geolong = cirrange(geolong + nlong/3600)
+    geolong = mod(geolong + nlong/3600, 360)
     λ = deg2rad(geolong)
     β = deg2rad(geolat)
     # Find mean obliquity and convert λ, β to right ascension and declination.
     ɛ = ten(23, 26) + @evalpoly(t/100, 21.448, -4680.93, -1.55, 1999.25, -51.38,
                                 -249.67, -39.05, 7.12, 27.87, 5.79, 2.45)/3600
     ɛ = deg2rad(ɛ + elong/3600)
-    ra = cirrange(atan2(sin(λ)*cos(ɛ) - tan(β)*sin(ɛ), cos(λ)), 2.*pi)
+    ra = mod2pi(atan2(sin(λ)*cos(ɛ) - tan(β)*sin(ɛ), cos(λ)))
     dec = asin(sin(β)*cos(ɛ) + cos(β)*sin(ɛ)*sin(λ))
     if radians
         return ra, dec, dis, λ, β

--- a/src/nutate.jl
+++ b/src/nutate.jl
@@ -43,16 +43,16 @@ function nutate(jd::AbstractFloat)
     # Number of Julian centuries since 2000-01-01T12:00:00
     t = (jd - J2000) / JULIANCENTURY
     # Mean elongation of the Moon
-    d = deg2rad(cirrange(@evalpoly(t, 297.85036, 445267.111480, -0.0019142, inv(189474))))
+    d = deg2rad(mod(@evalpoly(t, 297.85036, 445267.111480, -0.0019142, inv(189474)), 360))
     # Sun's mean anomaly
-    M = deg2rad(cirrange(@evalpoly(t, 357.52772, 35999.050340, -0.0001603, -inv(3e5))))
+    M = deg2rad(mod(@evalpoly(t, 357.52772, 35999.050340, -0.0001603, -inv(3e5)), 360))
     # Moon's mean anomaly
-    Mprime = deg2rad(cirrange(@evalpoly(t, 134.96298, 477198.867398, 0.0086972, inv(5.625e4))))
+    Mprime = deg2rad(mod(@evalpoly(t, 134.96298, 477198.867398, 0.0086972, inv(5.625e4)), 360))
     # Moon's argument of latitude
-    F = deg2rad(cirrange(@evalpoly(t, 93.27191, 483202.017538, -0.0036825, -inv(3.27270e5))))
+    F = deg2rad(mod(@evalpoly(t, 93.27191, 483202.017538, -0.0036825, -inv(3.27270e5)), 360))
     # Longitude of the ascending node of the Moon's mean orbit on the ecliptic,
     # measured from the mean equinox of the date
-    ω = deg2rad(cirrange(@evalpoly(t, 125.04452, -1934.136261, 0.0020708, inv(4.5e5))))
+    ω = deg2rad(mod(@evalpoly(t, 125.04452, -1934.136261, 0.0020708, inv(4.5e5)), 360))
     arg = d_lng .* d .+ M_lng .* M .+ Mprime_lng .* Mprime .+ F_lng .* F .+ ω_lng .* ω
     long  = sum((sdelt .* t .+ sin_lng) .* sin.(arg)) / 10000
     obliq = sum((cdelt .* t .+ cos_lng) .* cos.(arg)) / 10000

--- a/src/precess.jl
+++ b/src/precess.jl
@@ -18,9 +18,9 @@ function _precess{T<:AbstractFloat}(ra::T, dec::T, equinox1::T, equinox2::T,
     ra_rad  = atan2(x2[2], x2[1])
     dec_rad = asin(x2[3])
     if radians
-        return cirrange(ra_rad, 2 * T(pi)), dec_rad
+        return mod2pi(ra_rad), dec_rad
     else
-        return cirrange(rad2deg(ra_rad)), rad2deg(dec_rad)
+        return mod(rad2deg(ra_rad), 360), rad2deg(dec_rad)
     end
 end
 

--- a/src/radec.jl
+++ b/src/radec.jl
@@ -4,9 +4,9 @@
 function _radec{T<:AbstractFloat}(ra::T, dec::T, hours::Bool)
     # Compute right ascension.
     if hours
-        ra_hr, ra_min, ra_sec = sixty(cirrange(ra, 24))
+        ra_hr, ra_min, ra_sec = sixty(mod(ra, 24))
     else
-        ra_hr, ra_min, ra_sec = sixty(cirrange(ra) / 15)
+        ra_hr, ra_min, ra_sec = sixty(mod(ra, 360) / 15)
     end
     # Compute declination.
     dec_deg, dec_min, dec_sec = sixty(dec)

--- a/src/rhotheta.jl
+++ b/src/rhotheta.jl
@@ -18,7 +18,7 @@ function _rhotheta{T<:AbstractFloat}(period::T, periastron::T, eccentricity::T,
     theta = omega + atan2(sin(nu + omega2)*cos(inclination), cos(nu + omega2))
     rho   = r*cos(nu + omega2)/cos(theta - omega)
     # Convert theta to degrees and for it to be in [0, 360) range.
-    theta = cirrange(rad2deg(theta))
+    theta = mod(rad2deg(theta), 360)
     return rho, theta
 end
 

--- a/src/sunpos.jl
+++ b/src/sunpos.jl
@@ -50,7 +50,7 @@ function _sunpos{T<:AbstractFloat}(jd::T, radians::Bool)
     oblt = 23.452294 - 0.0130125 * t + 9.2 * cosd(omega) / 3600
     # Right Ascension and Declination
     l /= 3600
-    ra = cirrange(atan2(sind(l)*cosd(oblt), cosd(l)), 2pi)
+    ra = mod2pi(atan2(sind(l)*cosd(oblt), cosd(l)))
     dec = asin(sind(l)*sind(oblt))
     oblt = deg2rad(oblt)
     if radians

--- a/src/trueanom.jl
+++ b/src/trueanom.jl
@@ -48,7 +48,7 @@ plotting.
 using PyPlot
 M = linspace(0, 2pi, 1001)[1:end-1];
 for ecc in (0, 0.5, 0.9)
-    plot(M, cirrange.(trueanom.(kepler_solver.(M, ecc), ecc), 2pi))
+    plot(M, mod2pi.(trueanom.(kepler_solver.(M, ecc), ecc)))
 end
 ```
 

--- a/test/misc-tests.jl
+++ b/test/misc-tests.jl
@@ -1,11 +1,6 @@
 # This file is a part of AstroLib.jl. License is MIT "Expat".
 # Copyright (C) 2016 Mosè Giordano.
 
-# Test cirrange
-@test cirrange(12345) ≈ 105.0
-@test cirrange.([3*e, 10, -86.95, 6*pi], 2*pi) ≈
-    [1.8716601781975495, 3.7168146928204138, 1.0145943005142044, 0.0]
-
 @testset "ordinal" begin
     @test ordinal.([3, 32, 391, 2412, 1000000]) ==
         ["3rd", "32nd", "391st", "2412th", "1000000th"]


### PR DESCRIPTION
`cirrange` has a terrible name and it's identical to `mod`, just with a default second argument.