### PR TITLE
Add eq2hor function

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,6 @@ Missing in AstroLib.jl
 * `ccm_unred` (should go to [DustExtinction.jl](DustExtinction.jl))
 * `date`
 * `date_conv`
-* `eq2hor`
 * `eqpole_grid`
 * `fm_unred`
 * `gal_flat`

--- a/docs/src/ref.md
+++ b/docs/src/ref.md
@@ -96,6 +96,7 @@ julia> AstroLib.planets["saturn"].mass
 [`co_nutate()`](@ref),
 [`co_refract()`](@ref),
 [`eci2geo()`](@ref),
+[`eq2hor()`](@ref),
 [`eqpole()`](@ref),
 [`euler()`](@ref),
 [`gcirc()`](@ref),

--- a/src/co_nutate.jl
+++ b/src/co_nutate.jl
@@ -8,7 +8,7 @@ function _co_nutate(jd::T, ra::T, dec::T) where {T<:AbstractFloat}
     x = cosd(ra) * cosd(dec)
     y = sind(ra) * cosd(dec)
     z = sind(dec)
-    x2 = x - sec2rad(y * ce + z * ce) * d_psi
+    x2 = x - sec2rad(y * ce + z * se) * d_psi
     y2 = y + sec2rad(x * ce * d_psi - z * d_eps)
     z2 = z + sec2rad(x * se * d_psi + y * d_eps)
     xyproj = hypot(x2, y2)
@@ -69,7 +69,7 @@ julia> jd = jdcnv(2028,11,13,4,56)
 2.4620887055555554e6
 
 julia> co_nutate(jd,ten(2,46,11.331) * 15,ten(49,20,54.54))
-(0.006058053578186673, 0.0026508706103953728, 0.40904016038217555, 14.859389427896472, 2.703809037235058)
+(0.004400660977140092, 0.0017266864650764546, 0.40904016038217555, 14.85938942789647, 2.703809037235058)
 ```
 
 ### Notes ###

--- a/src/eq2hor.jl
+++ b/src/eq2hor.jl
@@ -1,0 +1,131 @@
+# This file is a part of AstroLib.jl. License is MIT "Expat".
+
+function _eq2hor(ra::T, dec::T, jd::T, lat::T, lon::T, altitude::T,
+                 pressure::T, temperature::T, ws::Bool, B1950::Bool,
+                 precession::Bool, nutate::Bool, aberration::Bool,
+                 refract::Bool,obsname::AbstractString) where {T<:AbstractFloat}
+
+    if obsname == ""
+        # Using Pine Bluff Observatory values
+        if isnan(lat)
+            lat = T(43.0783)
+        end
+
+        if isnan(lon)
+            lon = T(-89.865)
+        end
+    else
+        lat = T(observatories[obsname].latitude)
+        lon = T(observatories[obsname].longitude)
+        altitude = T(observatories[obsname].altitude)
+    end
+    j_now = (jd - J2000) / JULIANYEAR + 2000
+
+    if precession
+        if B1950
+            ra, dec = precess(ra, dec, j_now, 1950, FK4=true)
+        else
+            ra, dec = precess(ra, dec, j_now, 2000)
+        end
+    end
+    dra1, ddec1, eps, d_psi = co_nutate(jd, ra, dec)
+
+    if nutate
+       ra += dra1
+       dec += ddec1
+    end
+
+    if aberration
+        dra2, ddec2 = co_aberration(jd, ra, dec, eps)
+        ra += dra2 / 3600
+        dec += ddec2 / 3600
+    end
+    last = 15 * ct2lst(lon, jd) + d_psi * cos(eps) / 3600
+    ha = mod(last - ra, 360)
+    alt, az = hadec2altaz(ha, dec, lat, ws=ws)
+
+    if refract
+        alt = co_refract(alt, altitude, pressure, temperature)
+    end
+    return alt, az, ha
+end
+
+"""
+    eq2hor(ra, dec, jd[, ws=false, B1950=false, precession=true, nutate=true,
+           aberration=true, refract=true, lat=NaN, lon=NaN, altitude=0, pressure=NaN,
+           temperature=NaN, obsname="") -> alt, az, ha
+
+### Purpose ###
+
+Convert celestial  (ra-dec) coords to local horizon coords (alt-az).
+
+### Explanation ###
+
+This code calculates horizon (alt,az) coordinates from equatorial (ra,dec) coords.
+It performs precession, nutation, aberration, and refraction corrections.
+
+### Arguments ###
+
+* `ra`: right ascension of object, in degrees
+* `dec`: declination of object, in degrees
+* `jd`: julian date
+* `ws` (optional boolean keyword): set this to `true` to get the azimuth measured
+* `B1950` (optional boolean keyword): set this to `true` if the ra and dec
+  are specified in B1950 (FK4 coordinates) instead of J2000 (FK5). This is `false` by
+  default
+* `precession` (optional boolean keyword): set this to `false` for no precession
+  correction, `true` by default
+* `nutate` (optional boolean keyword): set this to `false` for no nutation,
+  `true` by default
+* `aberration` (optional boolean keyword): set this to `false` for no aberration
+  correction, `true` by default
+* `refract` (optional boolean keyword): set this to `false` for no refraction
+  correction, `true` by default
+* `lat` (optional keyword): north geodetic latitude of location, in degrees. Default
+  is `NaN`
+* `lon` (optional keyword): AST longitude of location, in degrees. You can specify west
+  longitude with a negative sign. Default value is `NaN`
+* `altitude` (optional keyword): the altitude of the observing location, in meters.
+  It is `0` by default
+* `pressure` (optional keyword): the pressure at the observing location, in millibars.
+  Default value is `NaN`
+* `temperature` (optional keyword): the temperature at the observing location, in Kelvins.
+  Default value is `NaN`
+* `obsname` (optional keyword): set this to a valid observatory name to
+  be used by the [Observatory](@ref) type, which will return the latitude and
+  longitude to be used by this program. This is `""` (empty string) by default,
+  in which case `lat` and `lon` default to the coordinates of the `Pine Bluff Observatory`
+  provided they are equivalent to `NaN` individually
+
+### Output ###
+
+* `alt`: altitude of horizon coords, in degrees
+* `az`: azimuth angle measured East from North (unless ws is `true`), in degrees
+* `ha`: hour angle, in degrees
+
+### Example ###
+
+```jldoctest
+julia> using AstroLib
+
+julia> alt_o, az_o = eq2hor(ten(6,40,58.2)*15, ten(9,53,44), 2460107.25, lat=ten(50,31,36),
+                                   lon=ten(6,51,18), altitude=369, pressure = 980, temperature=283)
+(16.040966354652365, 266.1447829865725, 76.7608239877382)
+
+julia> adstring(az_o, alt_o)
+" 17 44 34.7  +16 02 27"
+```
+
+### Notes ###
+
+Code of this function is based on IDL Astronomy User's Library.
+"""
+eq2hor(ra::Real, dec::Real, jd::Real; ws::Bool=false, B1950::Bool=false,
+       precession::Bool=true, nutate::Bool=true, aberration::Bool=true,
+       refract::Bool=true, lat::Real=NaN, lon::Real=NaN, altitude::Real=0,
+       pressure::Real=NaN, temperature::Real=NaN, obsname::AbstractString="") =
+           _eq2hor(promote(float(ra), float(dec), float(jd), float(lat), float(lon),
+                   float(altitude), float(temperature), float(pressure))..., ws, B1950,
+                   precession, nutate, aberration, refract, obsname)
+# TODO: Make eq2hor type-stable, which it isn't currently because of keyword arguments
+# Note that the inner function `_eq2hor` is type stable

--- a/src/eq2hor.jl
+++ b/src/eq2hor.jl
@@ -25,27 +25,27 @@ function _eq2hor(ra::T, dec::T, jd::T, lat::T, lon::T, altitude::T,
         if B1950
             ra, dec = precess(ra, dec, 1950, j_now, FK4=true)
         else
-            ra, dec = precess(ra, dec, 2000, j_now,)
+            ra, dec = precess(ra, dec, 2000, j_now)
         end
     end
     dra1, ddec1, eps, d_psi = co_nutate(jd, ra, dec)
-
-    if nutate
-       ra += dra1
-       dec += ddec1
-    end
 
     if aberration
         dra2, ddec2 = co_aberration(jd, ra, dec, eps)
         ra += dra2 / 3600
         dec += ddec2 / 3600
     end
+
+    if nutate
+       ra += dra1
+       dec += ddec1
+    end
     last = 15 * ct2lst(lon, jd) + d_psi * cos(eps) / 3600
     ha = mod(last - ra, 360)
     alt, az = hadec2altaz(ha, dec, lat, ws=ws)
 
     if refract
-        alt = co_refract(alt, altitude, pressure, temperature)
+        alt = co_refract(alt, altitude, pressure, temperature, to_observe = true)
     end
     return alt, az, ha
 end
@@ -110,10 +110,10 @@ julia> using AstroLib
 
 julia> alt_o, az_o = eq2hor(ten(6,40,58.2)*15, ten(9,53,44), 2460107.25, lat=ten(50,31,36),
                                    lon=ten(6,51,18), altitude=369, pressure = 980, temperature=283)
-(16.040966354652365, 266.1447829865725, 76.7608239877382)
+(16.423991509721567, 265.60656932130564, 76.11502253130612)
 
 julia> adstring(az_o, alt_o)
-" 17 44 34.7  +16 02 27"
+" 17 42 25.6  +16 25 26"
 ```
 
 ### Notes ###

--- a/src/eq2hor.jl
+++ b/src/eq2hor.jl
@@ -23,9 +23,9 @@ function _eq2hor(ra::T, dec::T, jd::T, lat::T, lon::T, altitude::T,
 
     if precession
         if B1950
-            ra, dec = precess(ra, dec, j_now, 1950, FK4=true)
+            ra, dec = precess(ra, dec, 1950, j_now, FK4=true)
         else
-            ra, dec = precess(ra, dec, j_now, 2000)
+            ra, dec = precess(ra, dec, 2000, j_now,)
         end
     end
     dra1, ddec1, eps, d_psi = co_nutate(jd, ra, dec)

--- a/src/hor2eq.jl
+++ b/src/hor2eq.jl
@@ -33,15 +33,15 @@ function _hor2eq(alt::T, az::T, jd::T, lat::T, lon::T, altitude::T,
     ra = mod(last - ha, 360)
     dra1, ddec1, eps = co_nutate(jd, ra, dec)
 
-    if nutate
-       ra -= dra1
-       dec -= ddec1
-    end
-
     if aberration
         dra2, ddec2 = co_aberration(jd, ra, dec, eps)
         ra -= dra2 / 3600
         dec -= ddec2 / 3600
+    end
+
+    if nutate
+       ra -= dra1
+       dec -= ddec1
     end
     j_now = (jd - J2000) / JULIANYEAR + 2000
 
@@ -122,8 +122,8 @@ and the pressure is 781 millibars. The Julian date for this time is 2466879.7083
 julia> using AstroLib
 
 julia> ra_o, dec_o = hor2eq(ten(37,54,41), ten(264,55,06), 2466879.7083333,
-                            obsname="kpno", pressure = 711, temperature = 273)
-(3.32228485671625, 15.19060567248328, 54.61193186104758)
+                            obsname="kpno", pressure = 781, temperature = 273)
+(3.3222617779538037, 15.190516725395284, 54.61193186104758)
 
 julia> adstring(ra_o, dec_o)
 " 00 13 17.3  +15 11 26"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -40,6 +40,9 @@ export deredd
 include("eci2geo.jl")
 export eci2geo
 
+include("eq2hor.jl")
+export eq2hor
+
 include("eqpole.jl")
 export eqpole
 

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -174,9 +174,9 @@ end
     @test alt_o ≈ 43.687900264047116
     @test az_o ≈ 56.68399934960606
     @test ha_o ≈ 291.0817909922114
-    ra_o, dec_o = hor2eq(eq2hor(45, 60, 2e6)[1:2]..., 2e6)
-    @test ra_o ≈ 45.0001735428487
-    @test dec_o ≈ 59.999995143349956
+    alt_o, az_o = eq2hor(hor2eq(25, 55, 2.05e6)[1:2]..., 2.05e6)
+    @test alt_o ≈ 24.99993224731665
+    @test az_o ≈ 54.99993893556545
 end
 
 # Test eqpole
@@ -409,6 +409,9 @@ end
     @test ra_o ≈ 259.52076321839485
     @test dec_o ≈ 49.62352289872951
     @test ha_o ≈ 291.0817908419628
+    ra_o, dec_o = hor2eq(eq2hor(45, 60, 2e6)[1:2]..., 2e6)
+    @test ra_o ≈ 45.0001735428487
+    @test dec_o ≈ 59.999995143349956
 end
 
 # Test imf

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -144,6 +144,38 @@ let
     @test alt  ≈ 10
 end
 
+# Test eq2hor
+# The values used for the testset are from running the code. However they have been
+# correlated with the output from eq2hor routine of IDL AstroLib, with
+# differences only in the least significant digits.
+@testset "eq2hor" begin
+    alt_o, az_o, ha_o = eq2hor(259.20005705918317, 49.674706171288655, AstroLib.J2000,
+                               B1950=true)
+    @test alt_o ≈ 44.07661421421705
+    @test az_o ≈ 56.73679950657327
+    @test ha_o ≈ 291.7183005916426
+    alt_o, az_o, ha_o = eq2hor(142.2933457820434,-34.218006262991786, 2e6, ws=true,
+                               B1950=true, precession = false, nutate=false,
+                               aberration=false, refract=false, lat = 54.435,
+                               lon = -34.78, altitude = 1000.34, pressure = 500.345,
+                               temperature = 293.343)
+    @test alt_o ≈ 1.3449999999999924
+    @test az_o ≈ 359.43
+    @test ha_o ≈ 359.3108663499664
+    alt_o, az_o, ha_o = eq2hor(3.32228485671625, 15.190605763758745, 2466879.7083333,
+                               obsname="kpno", pressure = 711, temperature = 273)
+    @test alt_o ≈ 36.76575213128887
+    @test az_o ≈ 265.0391331736532
+    @test ha_o ≈ 55.69534356650993
+    alt_o, az_o, ha_o = @inferred(AstroLib._eq2hor(259.5184384071214, 49.623310468816314,
+                                                   Float64(AstroLib.J2000), NaN, NaN, 0.0,
+                                                   NaN, NaN, false, false, true, true,
+                                                   true, true, ""))
+    @test alt_o ≈ 43.65317874635683
+    @test az_o ≈ 56.68399995567487
+    @test ha_o ≈ 291.08179162740964
+end
+
 # Test eqpole
 let
     local x, y

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -167,7 +167,7 @@ end
     @test alt_o ≈ 37.90681214212795
     @test az_o ≈ 264.91833348446283
     @test ha_o ≈ 54.61193216548776
-    alt_o, az_o, ha_o = @inferred(_eq2hor(259.5184384071214, 49.623310468816314,
+    alt_o, az_o, ha_o = @inferred(AstroLib._eq2hor(259.5184384071214, 49.623310468816314,
                                                    Float64(AstroLib.J2000), NaN, NaN, 0.0,
                                                    NaN, NaN, false, false, true, true,
                                                    true, true, ""))

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -151,9 +151,9 @@ end
 @testset "eq2hor" begin
     alt_o, az_o, ha_o = eq2hor(259.20005705918317, 49.674706171288655, AstroLib.J2000,
                                B1950=true)
-    @test alt_o ≈ 44.07661421421705
-    @test az_o ≈ 56.73679950657327
-    @test ha_o ≈ 291.7183005916426
+    @test alt_o ≈ 43.65317854138399
+    @test az_o ≈ 56.68399982431934
+    @test ha_o ≈ 291.0817912803288
     alt_o, az_o, ha_o = eq2hor(142.2933457820434,-34.218006262991786, 2e6, ws=true,
                                B1950=true, precession = false, nutate=false,
                                aberration=false, refract=false, lat = 54.435,
@@ -164,16 +164,19 @@ end
     @test ha_o ≈ 359.3108663499664
     alt_o, az_o, ha_o = eq2hor(3.32228485671625, 15.190605763758745, 2466879.7083333,
                                obsname="kpno", pressure = 711, temperature = 273)
-    @test alt_o ≈ 36.76575213128887
-    @test az_o ≈ 265.0391331736532
-    @test ha_o ≈ 55.69534356650993
-    alt_o, az_o, ha_o = @inferred(AstroLib._eq2hor(259.5184384071214, 49.623310468816314,
+    @test alt_o ≈ 37.90681214212795
+    @test az_o ≈ 264.91833348446283
+    @test ha_o ≈ 54.61193216548776
+    alt_o, az_o, ha_o = @inferred(_eq2hor(259.5184384071214, 49.623310468816314,
                                                    Float64(AstroLib.J2000), NaN, NaN, 0.0,
                                                    NaN, NaN, false, false, true, true,
                                                    true, true, ""))
     @test alt_o ≈ 43.65317874635683
     @test az_o ≈ 56.68399995567487
     @test ha_o ≈ 291.08179162740964
+    ra_o, dec_o = hor2eq(eq2hor(45, 60, 2e6)[1:2]..., 2e6)
+    @test ra_o ≈ 44.94115008739391
+    @test dec_o ≈ 59.997744863183605
 end
 
 # Test eqpole

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -84,11 +84,11 @@ end
 # the function here uses an updated method to find mean obliquity
 @testset "co_nutate" begin
     an,bn,cn,dn,en = co_nutate([jdcnv(2028,11,13,4,56), jdcnv(2013, 4, 16)],[10, 160],[80,30])
-    @test an ≈ [0.00332316985077874, 0.0028100303682379035  ]
-    @test bn ≈ [0.0037962761358869557, -0.002223911512604815]
-    @test cn ≈ [0.40904016038217567, 0.4090340058477726     ]
-    @test dn ≈ [14.8593894278967, 12.102640377483143        ]
-    @test en ≈ [2.7038090372351267, -5.86229256359996       ]
+    @test an ≈ [0.001209279097382776, 0.002465026741191423   ]
+    @test bn ≈ [0.0017471459185713911, -0.0018134211486149354]
+    @test cn ≈ [0.40904016038217567, 0.4090340058477726      ]
+    @test dn ≈ [14.8593894278967, 12.102640377483143         ]
+    @test en ≈ [2.7038090372351267, -5.86229256359996        ]
     ra_out, dec_out, eps_out, d_psi_out, d_eps_out = co_nutate(2.451545e6,325, 0)
     @test ra_out ≈ -0.0035484441576727477
     @test dec_out ≈ -0.00034017946720967174
@@ -149,11 +149,11 @@ end
 # correlated with the output from eq2hor routine of IDL AstroLib, with
 # differences only in the least significant digits.
 @testset "eq2hor" begin
-    alt_o, az_o, ha_o = eq2hor(259.20005705918317, 49.674706171288655, AstroLib.J2000,
+    alt_o, az_o, ha_o = eq2hor(259.20238631600944, 49.674907472176095, AstroLib.J2000,
                                B1950=true)
-    @test alt_o ≈ 43.65317854138399
-    @test az_o ≈ 56.68399982431934
-    @test ha_o ≈ 291.0817912803288
+    @test alt_o ≈ 43.68790027650299
+    @test az_o ≈ 56.68399935391907
+    @test ha_o ≈ 291.0817910119524
     alt_o, az_o, ha_o = eq2hor(142.2933457820434,-34.218006262991786, 2e6, ws=true,
                                B1950=true, precession = false, nutate=false,
                                aberration=false, refract=false, lat = 54.435,
@@ -162,21 +162,21 @@ end
     @test alt_o ≈ 1.3449999999999924
     @test az_o ≈ 359.43
     @test ha_o ≈ 359.3108663499664
-    alt_o, az_o, ha_o = eq2hor(3.32228485671625, 15.190605763758745, 2466879.7083333,
+    alt_o, az_o, ha_o = eq2hor(3.3222617779538037, 15.190516725395284, 2466879.7083333,
                                obsname="kpno", pressure = 711, temperature = 273)
-    @test alt_o ≈ 37.90681214212795
-    @test az_o ≈ 264.91833348446283
-    @test ha_o ≈ 54.61193216548776
-    alt_o, az_o, ha_o = @inferred(AstroLib._eq2hor(259.5184384071214, 49.623310468816314,
+    @test alt_o ≈ 37.91138916818937
+    @test az_o ≈ 264.918333213257
+    @test ha_o ≈ 54.61193155973385
+    alt_o, az_o, ha_o = @inferred(AstroLib._eq2hor(259.52076321839485, 49.62352289872951,
                                                    Float64(AstroLib.J2000), NaN, NaN, 0.0,
                                                    NaN, NaN, false, false, true, true,
                                                    true, true, ""))
-    @test alt_o ≈ 43.65317874635683
-    @test az_o ≈ 56.68399995567487
-    @test ha_o ≈ 291.08179162740964
+    @test alt_o ≈ 43.687900264047116
+    @test az_o ≈ 56.68399934960606
+    @test ha_o ≈ 291.0817909922114
     ra_o, dec_o = hor2eq(eq2hor(45, 60, 2e6)[1:2]..., 2e6)
-    @test ra_o ≈ 44.94115008739391
-    @test dec_o ≈ 59.997744863183605
+    @test ra_o ≈ 45.0001735428487
+    @test dec_o ≈ 59.999995143349956
 end
 
 # Test eqpole
@@ -387,8 +387,8 @@ end
 # differences only in the least significant digits.
 @testset "hor2eq" begin
     ra_o, dec_o, ha_o = hor2eq(43.6879, 56.684, AstroLib.J2000, B1950=true)
-    @test ra_o ≈ 259.20005705918317
-    @test dec_o ≈ 49.674706171288655
+    @test ra_o ≈ 259.20238631600944
+    @test dec_o ≈ 49.674907472176095
     @test ha_o ≈ 291.0817908419628
     ra_o, dec_o, ha_o = hor2eq(1.345, 359.43, 2e6, ws=true, B1950=true,
                                precession = false, nutate=false, aberration=false,
@@ -400,14 +400,14 @@ end
     @test ha_o ≈ 359.3108663499664
     ra_o, dec_o, ha_o = hor2eq(ten(37,54,41), ten(264,55,06), 2466879.7083333,
                                obsname="kpno", pressure = 711, temperature = 273)
-    @test ra_o ≈ 3.32228485671625
-    @test dec_o ≈ 15.190605763758745
+    @test ra_o ≈ 3.3222617779538037
+    @test dec_o ≈ 15.190516725395284
     @test ha_o ≈ 54.61193186104758
     ra_o, dec_o, ha_o = @inferred(AstroLib._hor2eq(43.6879, 56.684, Float64(AstroLib.J2000),
                                           NaN, NaN, 0.0, NaN, NaN, false, false, true,
                                           true, true, true, ""))
-    @test ra_o ≈ 259.5184384071214
-    @test dec_o ≈ 49.623310468816314
+    @test ra_o ≈ 259.52076321839485
+    @test dec_o ≈ 49.62352289872951
     @test ha_o ≈ 291.0817908419628
 end
 


### PR DESCRIPTION
The opposite of hor2eq, it has a similar type-stability flag due to the keyword arguments.

* TODO.md: Remove eq2hor from list.
* docs/src/ref.md: Add eq2hor entry to the manual.
* src/utils.jl: Add eq2hor entry to "utils".
* src/eq2hor.jl: Contains code of eq2hor function.
* test/util-tests.jl: Include tests for eq2hor.