### PR TITLE
Change arguments of eq2hor and hor2eq

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,13 @@
+History of AstroLib.jl
+======================
+
+v0.3.0 (2017-1?-??)
+-------------------
+
+### Breaking Changes
+
+* `eq2hor` and `hor2eq` now take as mandatory arguments either the name of an
+  observatory in `AstroLib.observatories` or the coordinates (latitude,
+  longitude and, optionally, altitude) of the observing site.  Keywords `lat`,
+  `lon`, `altitude` and `obsname` are no longer accepted.  There is no more a
+  default observing site, you always have to provide it.

--- a/src/common.jl
+++ b/src/common.jl
@@ -134,7 +134,10 @@ const observatories =
          "ctio"=>Observatory("Cerro Tololo Interamerican Observatory",
                              -30.16527778, -70.815, 2215., -4),
          "kpno"=>Observatory("Kitt Peak National Observatory",
-                             (31,57.8), (-111,36.0), 2120., -7))
+                             (31,57.8), (-111,36.0), 2120., -7),
+         # https://en.wikipedia.org/wiki/Pine_Bluff_Observatory
+         "pbo"=>Observatory("Pine Bluff Observatory",
+                            43.0777, -89.6717, 362, -6))
 
 """
 List of planets of the Solar System, from Mercury to Pluto.  The elements of the

--- a/src/eq2hor.jl
+++ b/src/eq2hor.jl
@@ -3,22 +3,8 @@
 function _eq2hor(ra::T, dec::T, jd::T, lat::T, lon::T, altitude::T,
                  pressure::T, temperature::T, ws::Bool, B1950::Bool,
                  precession::Bool, nutate::Bool, aberration::Bool,
-                 refract::Bool,obsname::AbstractString) where {T<:AbstractFloat}
+                 refract::Bool) where {T<:AbstractFloat}
 
-    if obsname == ""
-        # Using Pine Bluff Observatory values
-        if isnan(lat)
-            lat = T(43.0783)
-        end
-
-        if isnan(lon)
-            lon = T(-89.865)
-        end
-    else
-        lat = T(observatories[obsname].latitude)
-        lon = T(observatories[obsname].longitude)
-        altitude = T(observatories[obsname].altitude)
-    end
     j_now = (jd - J2000) / JULIANYEAR + 2000
 
     if precession
@@ -50,25 +36,61 @@ function _eq2hor(ra::T, dec::T, jd::T, lat::T, lon::T, altitude::T,
     return alt, az, ha
 end
 
-"""
-    eq2hor(ra, dec, jd[, ws=false, B1950=false, precession=true, nutate=true,
-           aberration=true, refract=true, lat=NaN, lon=NaN, altitude=0, pressure=NaN,
-           temperature=NaN, obsname="") -> alt, az, ha
+eq2hor(ra::Real, dec::Real, jd::Real, lat::Real, lon::Real, altitude::Real=0;
+       ws::Bool=false, B1950::Bool=false, precession::Bool=true, nutate::Bool=true,
+       aberration::Bool=true, refract::Bool=true, pressure::Real=NaN,
+       temperature::Real=NaN) =
+           _eq2hor(promote(float(ra), float(dec), float(jd), float(lat), float(lon),
+                           float(altitude), float(temperature), float(pressure))..., ws,
+                   B1950, precession, nutate, aberration, refract)
 
-### Purpose ###
+eq2hor(ra::Real, dec::Real, jd::Real, obsname::AbstractString; kwargs...) =
+    eq2hor(ra, dec, jd, observatories[obsname].latitude, observatories[obsname].longitude,
+           observatories[obsname].altitude; kwargs...)
+
+"""
+    eq2hor(ra, dec, jd[, obsname; ws=false, B1950=false, precession=true, nutate=true,
+           aberration=true, refract=true, pressure=NaN, temperature=NaN]) -> alt, az, ha
+
+    eq2hor(ra, dec, jd, lat, lon[, altitude=0; ws=false, B1950=false,
+           precession=true, nutate=true, aberration=true, refract=true,
+           pressure=NaN, temperature=NaN]) -> alt, az, ha
+
+
+### Purpose
 
 Convert celestial  (ra-dec) coords to local horizon coords (alt-az).
 
-### Explanation ###
+### Explanation
 
 This code calculates horizon (alt,az) coordinates from equatorial (ra,dec) coords.
 It performs precession, nutation, aberration, and refraction corrections.
 
-### Arguments ###
+### Arguments
+
+This function has two base methods.  With one you can specify the name of the observatory,
+if present in `AstroLib.observatories`, with the other one you can provide the coordinates
+of the observing site and, optionally, the altitude.
+
+Common mandatory arguments:
 
 * `ra`: right ascension of object, in degrees
 * `dec`: declination of object, in degrees
 * `jd`: julian date
+
+Other positional arguments:
+
+* `obsname`: set this to a valid observatory name in `AstroLib.observatories`.
+
+or
+
+* `lat`: north geodetic latitude of location, in degrees.
+* `lon`: AST longitude of location, in degrees. You can specify west longitude with a
+  negative sign.
+* `altitude`: the altitude of the observing location, in meters.  It is `0` by default
+
+Optional keyword arguments:
+
 * `ws` (optional boolean keyword): set this to `true` to get the azimuth measured
 * `B1950` (optional boolean keyword): set this to `true` if the ra and dec
   are specified in B1950 (FK4 coordinates) instead of J2000 (FK5). This is `false` by
@@ -81,51 +103,35 @@ It performs precession, nutation, aberration, and refraction corrections.
   correction, `true` by default
 * `refract` (optional boolean keyword): set this to `false` for no refraction
   correction, `true` by default
-* `lat` (optional keyword): north geodetic latitude of location, in degrees. Default
-  is `NaN`
-* `lon` (optional keyword): AST longitude of location, in degrees. You can specify west
-  longitude with a negative sign. Default value is `NaN`
-* `altitude` (optional keyword): the altitude of the observing location, in meters.
-  It is `0` by default
 * `pressure` (optional keyword): the pressure at the observing location, in millibars.
   Default value is `NaN`
 * `temperature` (optional keyword): the temperature at the observing location, in Kelvins.
   Default value is `NaN`
-* `obsname` (optional keyword): set this to a valid observatory name to
-  be used by the [Observatory](@ref) type, which will return the latitude and
-  longitude to be used by this program. This is `""` (empty string) by default,
-  in which case `lat` and `lon` default to the coordinates of the `Pine Bluff Observatory`
-  provided they are equivalent to `NaN` individually
 
-### Output ###
+### Output
 
 * `alt`: altitude of horizon coords, in degrees
 * `az`: azimuth angle measured East from North (unless ws is `true`), in degrees
 * `ha`: hour angle, in degrees
 
-### Example ###
+### Example
 
 ```jldoctest
 julia> using AstroLib
 
-julia> alt_o, az_o = eq2hor(ten(6,40,58.2)*15, ten(9,53,44), 2460107.25, lat=ten(50,31,36),
-                                   lon=ten(6,51,18), altitude=369, pressure = 980, temperature=283)
-(16.423991509721567, 265.60656932130564, 76.11502253130612)
+julia> alt_o, az_o = eq2hor(ten(6,40,58.2)*15, ten(9,53,44), 2460107.25, ten(50,31,36),
+                            ten(6,51,18), 369, pressure = 980, temperature=283)
+(16.42399150972157, 265.60656932130564, 76.11502253130612)
 
 julia> adstring(az_o, alt_o)
 " 17 42 25.6  +16 25 26"
 ```
 
-### Notes ###
+### Notes
 
 Code of this function is based on IDL Astronomy User's Library.
 """
-eq2hor(ra::Real, dec::Real, jd::Real; ws::Bool=false, B1950::Bool=false,
-       precession::Bool=true, nutate::Bool=true, aberration::Bool=true,
-       refract::Bool=true, lat::Real=NaN, lon::Real=NaN, altitude::Real=0,
-       pressure::Real=NaN, temperature::Real=NaN, obsname::AbstractString="") =
-           _eq2hor(promote(float(ra), float(dec), float(jd), float(lat), float(lon),
-                   float(altitude), float(temperature), float(pressure))..., ws, B1950,
-                   precession, nutate, aberration, refract, obsname)
+eq2hor
+
 # TODO: Make eq2hor type-stable, which it isn't currently because of keyword arguments
 # Note that the inner function `_eq2hor` is type stable

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -167,32 +167,31 @@ end
 # correlated with the output from eq2hor routine of IDL AstroLib, with
 # differences only in the least significant digits.
 @testset "eq2hor" begin
-    alt_o, az_o, ha_o = eq2hor(259.20238631600944, 49.674907472176095, AstroLib.J2000,
-                               B1950=true)
-    @test alt_o ≈ 43.68790027650299
-    @test az_o ≈ 56.68399935391907
-    @test ha_o ≈ 291.0817910119524
-    alt_o, az_o, ha_o = eq2hor(142.2933457820434,-34.218006262991786, 2e6, ws=true,
-                               B1950=true, precession = false, nutate=false,
-                               aberration=false, refract=false, lat = 54.435,
-                               lon = -34.78, altitude = 1000.34, pressure = 500.345,
-                               temperature = 293.343)
+    alt_o, az_o, ha_o = eq2hor(259.20238631600944, 49.674907472176095,
+                               AstroLib.J2000, "pbo", B1950=true)
+    @test alt_o ≈ 43.804935603297004
+    @test az_o ≈ 56.74141416977815
+    @test ha_o ≈ 291.2750910119525
+    alt_o, az_o, ha_o = eq2hor(142.2933457820434, -34.218006262991786, 2e6, 54.435, -34.78,
+                               1000.34, ws=true, B1950=true, precession = false,
+                               nutate=false, aberration=false,
+                               refract=false, pressure = 500.345, temperature = 293.343)
     @test alt_o ≈ 1.3449999999999924
     @test az_o ≈ 359.43
     @test ha_o ≈ 359.3108663499664
     alt_o, az_o, ha_o = eq2hor(3.3222617779538037, 15.190516725395284, 2466879.7083333,
-                               obsname="kpno", pressure = 711, temperature = 273)
+                               "kpno", pressure = 711, temperature = 273)
     @test alt_o ≈ 37.91138916818937
     @test az_o ≈ 264.918333213257
     @test ha_o ≈ 54.61193155973385
     alt_o, az_o, ha_o = @inferred(AstroLib._eq2hor(259.52076321839485, 49.62352289872951,
-                                                   Float64(AstroLib.J2000), NaN, NaN, 0.0,
-                                                   NaN, NaN, false, false, true, true,
-                                                   true, true, ""))
+                                                   Float64(AstroLib.J2000), 43.0783,
+                                                   -89.865, 0.0, NaN, NaN, false, false,
+                                                   true, true, true, true))
     @test alt_o ≈ 43.687900264047116
     @test az_o ≈ 56.68399934960606
     @test ha_o ≈ 291.0817909922114
-    alt_o, az_o = eq2hor(hor2eq(25, 55, 2.05e6)[1:2]..., 2.05e6)
+    alt_o, az_o = eq2hor(hor2eq(25, 55, 2.05e6, "pbo")[1:2]..., 2.05e6, "pbo")
     @test alt_o ≈ 24.99993224731665
     @test az_o ≈ 54.99993893556545
 end
@@ -394,30 +393,29 @@ end
 # correlated with the output from hor2eq routine of IDL AstroLib, with
 # differences only in the least significant digits.
 @testset "hor2eq" begin
-    ra_o, dec_o, ha_o = hor2eq(43.6879, 56.684, AstroLib.J2000, B1950=true)
-    @test ra_o ≈ 259.20238631600944
-    @test dec_o ≈ 49.674907472176095
-    @test ha_o ≈ 291.0817908419628
-    ra_o, dec_o, ha_o = hor2eq(1.345, 359.43, 2e6, ws=true, B1950=true,
-                               precession = false, nutate=false, aberration=false,
-                               refract=false, lat = 54.435, lon = -34.78,
-                               altitude = 1000.34, pressure = 500.345,
+    ra_o, dec_o, ha_o = hor2eq(43.6879, 56.684, AstroLib.J2000, "pbo", B1950=true)
+    @test ra_o ≈ 259.3943636338339
+    @test dec_o ≈ 49.67396411401468
+    @test ha_o ≈ 291.0833116221485
+    ra_o, dec_o, ha_o = hor2eq(1.345, 359.43, 2e6, 54.435, -34.78, 1000.34, ws=true,
+                               B1950=true, precession = false, nutate=false,
+                               aberration=false, refract=false, pressure = 500.345,
                                temperature = 293.343)
     @test ra_o ≈ 142.2933457820434
     @test dec_o ≈ -34.218006262991786
     @test ha_o ≈ 359.3108663499664
     ra_o, dec_o, ha_o = hor2eq(ten(37,54,41), ten(264,55,06), 2466879.7083333,
-                               obsname="kpno", pressure = 711, temperature = 273)
+                               "kpno", pressure = 711, temperature = 273)
     @test ra_o ≈ 3.3222617779538037
     @test dec_o ≈ 15.190516725395284
     @test ha_o ≈ 54.61193186104758
     ra_o, dec_o, ha_o = @inferred(AstroLib._hor2eq(43.6879, 56.684, Float64(AstroLib.J2000),
-                                          NaN, NaN, 0.0, NaN, NaN, false, false, true,
-                                          true, true, true, ""))
+                                                   43.0783, -89.865, 0.0, NaN, NaN, false,
+                                                   false, true, true, true, true))
     @test ra_o ≈ 259.52076321839485
     @test dec_o ≈ 49.62352289872951
     @test ha_o ≈ 291.0817908419628
-    ra_o, dec_o = hor2eq(eq2hor(45, 60, 2e6)[1:2]..., 2e6)
+    ra_o, dec_o = hor2eq(eq2hor(45, 60, 2e6, "pbo")[1:2]..., 2e6, "pbo")
     @test ra_o ≈ 45.0001735428487
     @test dec_o ≈ 59.999995143349956
 end


### PR DESCRIPTION
With this PR `eq2hor` and `hor2eq` take as mandatory arguments either the name of an observatory in `AstroLib.observatories` or the coordinates (latitude, longitude and, optionally, altitude) of the observing site.  Keywords `lat`, `lon`, `altitude` and `obsname` are no longer accepted.  In addition, there is no more a default observing site that must be set explicitly.