### PR TITLE
Fix the example in the documentation

### DIFF
--- a/src/sunpos.jl
+++ b/src/sunpos.jl
@@ -116,7 +116,9 @@ degrees, for every day in 2016.  Use
 
 ```julia
 using PyPlot
-days = DateTime(2016):DateTime(2016, 12, 31);
+using Dates
+
+days = DateTime(2016):Day(1):DateTime(2016, 12, 31);
 ra, declin = sunpos(jdcnv.(days));
 plot(days, ra/15); plot(days, declin)
 ```


### PR DESCRIPTION
On Julia 1.1, the second example in the documentation fails with the message: "ERROR: MethodError: Cannot `convert` an object of type Int64 to an object of type Millisecond". The fix makes the example runnable again.