### PR TITLE
Add missing line to eq2hor docstring

### DIFF
--- a/src/eq2hor.jl
+++ b/src/eq2hor.jl
@@ -92,6 +92,7 @@ or
 Optional keyword arguments:
 
 * `ws` (optional boolean keyword): set this to `true` to get the azimuth measured
+  westward from south (not East of North)
 * `B1950` (optional boolean keyword): set this to `true` if the ra and dec
   are specified in B1950 (FK4 coordinates) instead of J2000 (FK5). This is `false` by
   default


### PR DESCRIPTION
I was confused about this `ws` parameter until I realized that this function is copied directly from IDL, so I looked up the [`eq2hor` IDL documentation](https://idlastro.gsfc.nasa.gov/ftp/pro/astro/eq2hor.pro) and it turned out half of the description had been forgotten.