### PR TITLE
Use more specific error types

### DIFF
--- a/src/aitoff.jl
+++ b/src/aitoff.jl
@@ -69,7 +69,9 @@ aitoff(l::Real, b::Real) = aitoff(promote(float(l), float(b))...)
 aitoff(lb::Tuple{Real, Real}) = aitoff(lb...)
 
 function aitoff(l::AbstractArray{L}, b::AbstractArray{B}) where {L<:Real,B<:Real}
-    @assert length(l) == length(b)
+    if length(l) != length(b)
+        throw(ArgumentError("l and b arrays must have the same length"))
+    end
     typel = float(L)
     x = similar(l, typel)
     y = similar(b, typel)

--- a/src/altaz2hadec.jl
+++ b/src/altaz2hadec.jl
@@ -88,7 +88,9 @@ altaz2hadec(altaz::Tuple{Real, Real}, lat::Real) = altaz2hadec(altaz..., lat)
 
 function altaz2hadec(alt::AbstractArray{R}, az::AbstractArray{<:Real},
                      lat::AbstractArray{<:Real}) where {R<:Real}
-    @assert length(alt) == length(az) == length(lat)
+    if !(length(alt) == length(az) == length(lat))
+        throw(ArgumentError("alt, az, and lat arrays must have the same length"))
+    end
     typealt = float(R)
     ha  = similar(alt, typealt)
     dec = similar(alt, typealt)

--- a/src/bprecess.jl
+++ b/src/bprecess.jl
@@ -20,7 +20,9 @@ const Mbprec =
 # commented, in case someone is interested.
 function _bprecess(ra::T, dec::T, parallax::T, radvel::T,
                    epoch::T, muradec::Vector{T}) where {T<:AbstractFloat}
-    @assert length(muradec) == 2
+    if length(muradec) != 2
+        throw(DomainError("muradec must have length 2"))
+    end
     sinra,  cosra  = sincos(deg2rad(ra))
     sindec, cosdec = sincos(deg2rad(dec))
     r0 = SVector(cosra*cosdec,  sinra*cosdec,  sindec)
@@ -91,7 +93,10 @@ function bprecess(ra::AbstractArray{R}, dec::AbstractArray{<:Real},
                   muradec::AbstractArray{<:Real};
                   parallax::AbstractArray{<:Real}=zeros(R, length(ra)),
                   radvel::AbstractArray{<:Real}=zeros(R, length(ra))) where {R<:Real}
-    @assert length(ra) == length(dec) == size(muradec)[2] == length(parallax) == length(radvel)
+    if !(length(ra) == length(dec) == size(muradec, 2) == length(parallax) == length(radvel))
+        throw(ArgumentError(
+            "ra, dec, muradec[:,2], parallax, and radvel arrays should be of the same length"))
+    end
     typer = float(R)
     ra1950  = similar(ra, typer)
     dec1950 = similar(dec, typer)
@@ -104,7 +109,9 @@ end
 
 function bprecess(ra::AbstractArray{R}, dec::AbstractArray{D},
                   epoch::Real=2000.0) where {R<:Real,D<:Real}
-    @assert length(ra) == length(dec)
+    if length(ra) != length(dec)
+        throw(ArgumentError("ra and dec arrays should be of the same length"))
+    end
     typer = float(R)
     ra1950  = similar(ra, typer)
     dec1950 = similar(dec, typer)

--- a/src/co_aberration.jl
+++ b/src/co_aberration.jl
@@ -84,7 +84,9 @@ co_aberration(jd::Real, ra::Real, dec::Real, eps::Real=NaN) =
 
 function co_aberration(jd::AbstractVector{R}, ra::AbstractVector{R},
                        dec::AbstractVector{R}, eps::Real=NaN) where {R<:Real}
-    @assert length(jd) == length(ra) == length(dec) "jd, ra and dec vectors should be of the same length"
+    if !(length(jd) == length(ra) == length(dec))
+        throw(ArgumentError("jd, ra and dec vectors should be of the same length"))
+    end
     typejd = float(R)
     ra_out  = similar(ra,  typejd)
     dec_out = similar(dec, typejd)

--- a/src/co_nutate.jl
+++ b/src/co_nutate.jl
@@ -87,8 +87,9 @@ co_nutate(jd::Real, ra::Real, dec::Real) =
 
 function co_nutate(jd::AbstractVector{P}, ra::AbstractVector{<:Real},
                    dec::AbstractVector{<:Real}) where {P<:Real}
-    @assert length(jd) == length(ra) == length(dec) "jd, ra and dec vectors
-                                                     should be of the same length"
+    if !(length(jd) == length(ra) == length(dec))
+        throw(ArgumentError("jd, ra and dec vectors should be of the same length"))
+    end
     typejd = float(P)
     ra_out  = similar(jd,  typejd)
     dec_out = similar(dec, typejd)

--- a/src/deredd.jl
+++ b/src/deredd.jl
@@ -56,7 +56,9 @@ deredd(Eby::Real, by::Real, m1::Real, c1::Real, ub::Real) =
 function deredd(Eby::AbstractArray{E}, by::AbstractArray{<:Real},
                 m1::AbstractArray{<:Real}, c1::AbstractArray{<:Real},
                 ub::AbstractArray{<:Real}) where {E<:Real}
-    @assert length(Eby) == length(by) == length(m1) == length(c1) == length(ub)
+    if !(length(Eby) == length(by) == length(m1) == length(c1) == length(ub))
+        throw(ArgumentError("Eby, by, m1, c1, and ub arrays should be of the same length"))
+    end
     typeeby = float(E)
     by0 = similar(Eby, typeeby)
     m0  = similar(Eby, typeeby)

--- a/src/eci2geo.jl
+++ b/src/eci2geo.jl
@@ -85,7 +85,9 @@ eci2geo(xyz::Tuple{Real, Real, Real}, jd::Real) =
 
 function eci2geo(x::AbstractArray{X}, y::AbstractArray{<:Real}, z::AbstractArray{<:Real},
                  jd::AbstractArray{<:Real}) where {X<:Real}
-    @assert length(x) == length(y) == length(z) == length(jd)
+    if !(length(x) == length(y) == length(z) == length(jd))
+        throw(ArgumentError("x, y, z, and jd arrays should be of the same length"))
+    end
     typex = float(X)
     lat  = similar(x, typex)
     long = similar(x, typex)

--- a/src/eqpole.jl
+++ b/src/eqpole.jl
@@ -61,7 +61,9 @@ eqpole(l::Real, b::Real; southpole::Bool=false) =
 
 function eqpole(l::AbstractArray{L}, b::AbstractArray{<:Real};
                 southpole::Bool=false) where {L<:Real}
-    @assert length(l) == length(b)
+    if length(l) != length(b)
+        throw(ArgumentError("l and b arrays should be of the same length"))
+    end
     typel = float(L)
     x = similar(l, typel)
     y = similar(l, typel)

--- a/src/euler.jl
+++ b/src/euler.jl
@@ -3,7 +3,8 @@
 function _euler(ai::T, bi::T, select::Integer, FK4::Bool, radians::Bool) where {T<:AbstractFloat}
 
     if select>6 || select<1
-        error("Input for coordinate transformation should be an integer in the range 1:6")
+        throw(DomainError(
+            "Input for coordinate transformation should be an integer in the range 1:6"))
     end
 
     if FK4
@@ -98,7 +99,9 @@ euler(aibi::Tuple{Real, Real}, select::Integer; FK4::Bool=false, radians::Bool=f
 
 function euler(ai::AbstractVector{R}, bi::AbstractVector{<:Real}, select::Integer;
                FK4::Bool=false, radians::Bool=false) where {R<:Real}
-    @assert length(ai) == length(bi) "ai and bi arrays should be of the same length"
+    if length(ai) != length(bi)
+        throw(ArgumentError("ai and bi arrays should be of the same length"))
+    end
     typeai = float(R)
     ai_out  = similar(ai,  typeai)
     bi_out = similar(bi, typeai)

--- a/src/gal_uvw.jl
+++ b/src/gal_uvw.jl
@@ -131,8 +131,11 @@ function gal_uvw(ra::AbstractArray{R}, dec::AbstractArray{<:Real},
                  pmra::AbstractArray{<:Real}, pmdec::AbstractArray{<:Real},
                  vrad::AbstractArray{<:Real}, plx::AbstractArray{<:Real};
                  lsr::Bool=false) where {R<:Real}
-    @assert length(ra) == length(dec) == length(pmra) ==
-        length(pmdec) == length(vrad) == length(plx)
+    if !(length(ra) == length(dec) == length(pmra) ==
+         length(pmdec) == length(vrad) == length(plx))
+        throw(ArgumentError(
+            "ra, dec, pmra, pmdec, vrad, and plx arrays must all have the same length"))
+    end
     typer = float(R)
     u = similar(ra, typer)
     v = similar(ra, typer)

--- a/src/gcirc.jl
+++ b/src/gcirc.jl
@@ -23,7 +23,8 @@ function gcirc(units::Integer, ra1::T, dec1::T, ra2::T, dec2::T) where {T<:Abstr
         φ_2 = deg2rad(dec2)
     else
         # In any other case throw an error.
-        error("units must be 0 (radians), 1 (hours, degrees) or 2 (degrees)")
+        throw(DomainError(
+            "units must be 0 (radians), 1 (hours, degrees) or 2 (degrees)"))
     end
     Δφ_2 = (φ_2 - φ_1) * 0.5
     Δλ_2 = (λ_2 - λ_1) * 0.5

--- a/src/geo2eci.jl
+++ b/src/geo2eci.jl
@@ -78,7 +78,10 @@ geo2eci(lla::Tuple{Real, Real, Real}, jd::Real) =
 function geo2eci(lat::AbstractArray{LA}, long::AbstractArray{<:Real},
                  alt::AbstractArray{<:Real},
                  jd::AbstractArray{<:Real}) where {LA<:Real}
-    @assert length(lat) == length(long) == length(alt) == length(jd)
+    if !(length(lat) == length(long) == length(alt) == length(jd))
+        throw(ArgumentError(
+            "lat, long, alt, and jd arrays must have the same length"))
+    end
     typela = float(LA)
     x = similar(lat, typela)
     y = similar(lat, typela)

--- a/src/geo2geodetic.jl
+++ b/src/geo2geodetic.jl
@@ -159,7 +159,9 @@ geo2geodetic(lla::Tuple{Real, Real, Real}, eq::Real, pol::Real) =
 function geo2geodetic(lat::AbstractArray{LA}, long::AbstractArray{<:Real},
                       alt::AbstractArray{<:Real},
                       eq::Real, pol::Real) where {LA<:Real}
-    @assert length(lat) == length(long) == length(alt)
+    if !(length(lat) == length(long) == length(alt))
+        throw(ArgumentError("lat, long, and alt arrays must have the same length"))
+    end
     typela  = float(LA)
     outlat  = similar(lat, typela)
     outlong = similar(lat, typela)
@@ -183,7 +185,9 @@ geo2geodetic(lla::Tuple{Real, Real, Real}, planet::AbstractString="earth") =
 function geo2geodetic(lat::AbstractArray{LA}, long::AbstractArray{<:Real},
                       alt::AbstractArray{<:Real},
                       planet::AbstractString="earth") where {LA<:Real}
-    @assert length(lat) == length(long) == length(alt)
+    if !(length(lat) == length(long) == length(alt))
+        throw(ArgumentError("lat, long, and alt arrays must have the same length"))
+    end
     typela  = float(LA)
     outlat  = similar(lat, typela)
     outlong = similar(lat, typela)

--- a/src/geo2mag.jl
+++ b/src/geo2mag.jl
@@ -89,7 +89,9 @@ geo2mag(lat::Real, long::Real, year::Real=Dates.year(Dates.now())) =
 
 function geo2mag(lat::AbstractArray{LA}, long::AbstractArray{<:Real},
                  year::Real=Dates.year(Dates.now())) where {LA<:Real}
-    @assert length(lat) == length(long)
+    if length(lat) != length(long)
+        throw(ArgumentError("lat and long arrays should be of the same length"))
+    end
     typela   = float(LA)
     maglat   = similar(lat, typela)
     maglong  = similar(lat, typela)

--- a/src/geodetic2geo.jl
+++ b/src/geodetic2geo.jl
@@ -126,7 +126,9 @@ geodetic2geo(lla::Tuple{Real, Real, Real}, eq::Real, pol::Real) =
 function geodetic2geo(lat::AbstractArray{LA}, long::AbstractArray{<:Real},
                       alt::AbstractArray{<:Real}, eq::Real,
                       pol::Real) where {LA<:Real}
-    @assert length(lat) == length(long) == length(alt)
+    if !(length(lat) == length(long) == length(alt))
+        throw(ArgumentError("lat, long, and alt arrays must have the same length"))
+    end
     typela  = float(LA)
     outlat  = similar(lat, typela)
     outlong = similar(lat, typela)
@@ -151,7 +153,9 @@ function geodetic2geo(lat::AbstractArray{LA},
                       long::AbstractArray{<:Real},
                       alt::AbstractArray{<:Real},
                       planet::AbstractString="earth") where {LA<:Real}
-    @assert length(lat) == length(long) == length(alt)
+    if !(length(lat) == length(long) == length(alt))
+        throw(ArgumentError("lat, long, and alt arrays must have the same length"))
+    end
     typela  = float(LA)
     outlat  = similar(lat, typela)
     outlong = similar(lat, typela)

--- a/src/hadec2altaz.jl
+++ b/src/hadec2altaz.jl
@@ -85,7 +85,9 @@ hadec2altaz(hadec::Tuple{Real, Real}, lat::Real; ws::Bool=false) =
 
 function hadec2altaz(ha::AbstractArray{R}, dec::AbstractArray{<:Real},
                      lat::AbstractArray{<:Real}; ws::Bool=false) where {R<:Real}
-    @assert length(ha) == length(dec) == length(lat)
+    if !(length(ha) == length(dec) == length(lat))
+        throw(ArgumentError("ha, dec, and lat arrays must have the same length"))
+    end
     typeha = float(R)
     alt = similar(ha, typeha)
     az  = similar(ha, typeha)

--- a/src/helio.jl
+++ b/src/helio.jl
@@ -18,7 +18,7 @@ const record = Dict(1=>"mercury", 2=>"venus", 3=>"earth", 4=>"mars", 5=>"jupiter
 function _helio(jd::T, num::Integer, radians::Bool) where {T<:AbstractFloat}
 
     if num<1 || num>9
-        error("Input should be an integer in the range 1:9 denoting planet number")
+        throw(DomainError("Input should be an integer in the range 1:9 denoting planet number"))
     end
     t = (jd - J2000) / JULIANCENTURY
     body = record[num]
@@ -115,8 +115,9 @@ helio(jd::Real, num::Integer, radians::Bool=false) =
 
 function helio(jd::AbstractVector{P}, num::AbstractVector{<:Real},
                radians::Bool = false) where {P<:Real}
-    @assert length(jd) == length(num) "jd and num vectors should
-                                       be of the same length"
+    if length(jd) != length(num)
+        throw(ArgumentError("jd and num vectors should be of the same length"))
+    end
     typejd = float(P)
     hrad_out = similar(jd,  typejd)
     hlong_out = similar(jd,  typejd)

--- a/src/imf.jl
+++ b/src/imf.jl
@@ -4,7 +4,8 @@ function imf(mass::AbstractVector{T}, expon::AbstractVector{T},
              mass_range::AbstractVector{T}) where {T<:AbstractFloat}
     ne_comp = length(expon)
     if length(mass_range) != ne_comp + 1
-        error("Length of array mass_range is not one more than that of expon")
+        throw(ArgumentError(
+            "Length of array mass_range is not one more than that of expon"))
     end
     integ = Vector{T}(undef, ne_comp)
     joint = ones(T, ne_comp)
@@ -19,10 +20,10 @@ function imf(mass::AbstractVector{T}, expon::AbstractVector{T},
             joint[i] = joint[i-1]*(mass_range[i]^(expon[i-1] - expon[i]))
         end
     end
-    norm = joint./(dot(integ, joint))
+    norm = joint ./ (dot(integ, joint))
     psi = fill!(similar(mass), 0)
     for i = 1:ne_comp
-        test = findall(mass_range[i].< mass.<mass_range[i+1])
+        test = findall(mass_range[i] .<  mass .< mass_range[i+1])
         if length(test) !=0
             psi[test] = norm[i].*(mass[test].^expon[i])
         end

--- a/src/jprecess.jl
+++ b/src/jprecess.jl
@@ -20,7 +20,9 @@ const Mjprec =
 # commented, in case someone is interested.
 function _jprecess(ra::T, dec::T, parallax::T, radvel::T, epoch::T,
                    muradec::Vector{T}) where {T<:AbstractFloat}
-    @assert length(muradec) == 2
+    if length(muradec) != 2
+        throw(DomainError("muradec must have length 2"))
+    end
     sinra, cosra  = sincos(deg2rad(ra))
     sindec, cosdec = sincos(deg2rad(dec))
     if isfinite(epoch) && epoch != 1950
@@ -94,7 +96,11 @@ function jprecess(ra::AbstractArray{R}, dec::AbstractArray{<:Real},
                   muradec::AbstractArray{<:Real};
                   parallax::AbstractArray{<:Real}=zeros(R, length(ra)),
                   radvel::AbstractArray{<:Real}=zeros(R, length(ra))) where {R<:Real}
-    @assert length(ra) == length(dec) == size(muradec)[2] == length(parallax) == length(radvel)
+    if !(length(ra) == length(dec) == size(muradec)[2] == length(parallax) == length(radvel))
+        # TODO write more helpful error message
+        throw(ArgumentError(
+            "ra, dec, muradec[:,2], parallax, and radvel must have the same length"))
+    end
     typer = float(R)
     ra2000  = similar(ra, typer)
     dec2000 = similar(dec, typer)
@@ -107,7 +113,9 @@ end
 
 function jprecess(ra::AbstractArray{R}, dec::AbstractArray{<:Real},
                   epoch::Real=1950.0) where {R<:Real}
-    @assert length(ra) == length(dec)
+    if length(ra) != length(dec)
+        throw(ArgumentError("ra and dec arrays should be of the same length"))
+    end
     typer = float(R)
     ra2000  = similar(ra, typer)
     dec2000 = similar(dec, typer)

--- a/src/juldate.jl
+++ b/src/juldate.jl
@@ -62,10 +62,11 @@ function juldate(dt::DateTime)
         Dates.hour(dt), Dates.minute(dt),
         Dates.second(dt), Dates.millisecond(dt)
 
+    if year == 0
+        throw(DomainError("There is no year zero in Julian Calendar"))
+    end
     if year < 0
         year += 1
-    elseif year == 0
-        error("There is no year zero in Julian Calendar")
     end
     # Do not include leap year in January and February.
     if month < 3

--- a/src/kepler_solver.jl
+++ b/src/kepler_solver.jl
@@ -2,7 +2,9 @@
 # Copyright (C) 2016 Mosè Giordano.
 
 function kepler_solver(_M::Real, e::Real)
-    @assert 0 <= e <= 1 "eccentricity must be in the range [0, 1]"
+    if e < 0 || e > 1
+        throw(DomainError("eccentricity must be in the range [0, 1]"))
+    end
     # M must be in the range [-pi, pi], see Markley (1995), page 2.
     M = rem2pi(_M, RoundNearest)
     T = float(promote_type(typeof(M), typeof(e)))

--- a/src/mag2geo.jl
+++ b/src/mag2geo.jl
@@ -93,7 +93,9 @@ mag2geo(lat::Real, long::Real, year::Real=Dates.year(Dates.now())) =
 
 function mag2geo(lat::AbstractArray{LA}, long::AbstractArray{LO},
                  year::Real=Dates.year(Dates.now())) where {LA<:Real, LO<:Real}
-    @assert length(lat) == length(long)
+    if length(lat) != length(long)
+        throw(ArgumentError("lat and long arrays should be of the same length"))
+    end
     typela   = float(LA)
     geolat   = similar(lat, typela)
     geolong  = similar(lat, typela)

--- a/src/ordinal.jl
+++ b/src/ordinal.jl
@@ -39,7 +39,7 @@ Code of this function is based on IDL Astronomy User's Library.
 """
 function ordinal(num::Integer)
     a = num % 100
-    if a== 11 || a == 12 || a == 13
+    if a == 11 || a == 12 || a == 13
         suffix = "th"
     else
         a = num % 10

--- a/src/planet_coords.jl
+++ b/src/planet_coords.jl
@@ -67,7 +67,9 @@ planet_coords(date::Real, num::Integer) = _planet_coords(float(date), num)
 
 function planet_coords(date::AbstractVector{R},
                        num::AbstractVector{<:Integer}) where {R<:Real}
-    @assert length(date) == length(num) "date and num arrays should be of the same length"
+    if length(date) != length(num)
+      throw(ArgumentError("date and num arrays should be of the same length"))
+    end
     typedate = float(R)
     ra_out  = similar(date, typedate)
     dec_out = similar(date, typedate)

--- a/src/polrec.jl
+++ b/src/polrec.jl
@@ -58,7 +58,9 @@ polrec(r_a::Tuple{Real, Real}; degrees::Bool=false) = polrec(r_a...,
 
 function polrec(r::AbstractArray{R}, a::AbstractArray{A};
                 degrees::Bool=false) where {R<:Real, A<:Real}
-    @assert length(r) == length(a)
+    if length(r) != length(a)
+        throw(ArgumentError("r and a arrays should be of the same length"))
+    end
     typer = float(R)
     x = similar(r, typer)
     y = similar(r, typer)

--- a/src/posang.jl
+++ b/src/posang.jl
@@ -23,7 +23,8 @@ function posang(units::Integer, ra1::T, dec1::T, ra2::T, dec2::T) where {T<:Abst
         dec2_rad = deg2rad(dec2)
     else
         # In any other case throw an error.
-        error("units must be 0 (radians), 1 (hours, degrees) or 2 (degrees)")
+        throw(DomainError(
+            "units must be 0 (radians), 1 (hours, degrees) or 2 (degrees)"))
     end
     sin_radif, cos_radif = sincos(ra2_rad - ra1_rad)
     sin_dec1, cos_dec1 = sincos(dec1_rad)

--- a/src/precess.jl
+++ b/src/precess.jl
@@ -112,7 +112,9 @@ precess(radec::Tuple{Real, Real}, equinox1::Real, equinox2::Real;
 function precess(ra::AbstractArray{R}, dec::AbstractArray{D}, equinox1::Real,
                  equinox2::Real; FK4::Bool=false,
                  radians::Bool=false) where {R<:Real, D<:Real}
-    @assert length(ra) == length(dec) "ra and dec arrays should be of the same length"
+    if length(ra) != length(dec)
+        throw(ArgumentError("ra and dec arrays should be of the same length"))
+    end
     typera = float(R)
     ra_out  = similar(ra,  typera)
     dec_out = similar(dec, typera)

--- a/src/precess_xyz.jl
+++ b/src/precess_xyz.jl
@@ -64,7 +64,9 @@ precess_xyz(xyz::Tuple{Real, Real, Real}, equinox1::Real, equinox2::Real) =
 function precess_xyz(x::AbstractArray{X}, y::AbstractArray{<:Real},
                      z::AbstractArray{<:Real}, equinox1::Real,
                      equinox2::Real) where {X<:Real}
-    @assert length(x) == length(y) == length(z) "x, y, z arrays should be of the same length"
+    if !(length(x) == length(y) == length(z))
+        throw(ArgumentError("x, y, z arrays should be of the same length"))
+    end
     typex = float(X)
     x_out = similar(x, typex)
     y_out = similar(x, typex)

--- a/src/radec.jl
+++ b/src/radec.jl
@@ -60,7 +60,9 @@ radec(ra::Real, dec::Real; hours::Bool=false) =
 
 function radec(ra::AbstractArray{R}, dec::AbstractArray{D};
                hours::Bool=false) where {R<:Real, D<:Real}
-    @assert length(ra) == length(dec)
+    if length(ra) != length(dec)
+        throw(ArgumentError("ra and dec arrays should be of the same length"))
+    end
     typera = float(R)
     ra_hr   = similar(ra, typera)
     ra_min  = similar(ra, typera)

--- a/src/recpol.jl
+++ b/src/recpol.jl
@@ -63,7 +63,9 @@ recpol(xy::Tuple{Real, Real}; degrees::Bool=false) =
 
 function recpol(x::AbstractArray{X}, y::AbstractArray{Y};
                 degrees::Bool=false) where {X<:Real, Y<:Real}
-    @assert length(x) == length(y)
+    if length(x) != length(y)
+        throw(ArgumentError("x and y arrays must have the same length"))
+    end
     typex = float(X)
     r = similar(x, typex)
     a = similar(x, typex)

--- a/src/trueanom.jl
+++ b/src/trueanom.jl
@@ -2,7 +2,9 @@
 # Copyright (C) 2016 Mosè Giordano.
 
 function trueanom(E::T, e::T) where {T<:AbstractFloat}
-    @assert e >= 0 "eccentricity must be in the range [0, 1]"
+    if e < 0 || e > 1
+        throw(DomainError("eccentricity must be in the range [0, 1]"))
+    end
     return 2 * atan(sqrt((1 + e) / (1 - e)) * tan(E / 2))
 end
 

--- a/src/uvbybeta.jl
+++ b/src/uvbybeta.jl
@@ -4,8 +4,9 @@ function _uvbybeta(by::T, m1::T, c1::T, hbeta::T, eby_in::T,
                    n::Integer) where {T<:AbstractFloat}
     # Rm1 = -0.33 & Rc1 = 0.19 & Rub = 1.53
     if n < 1 || n > 8
-      error("Input should be an integer in the range 1:8, giving approximate
-            stellar classification")
+        throw(DomainError(
+            "Input should be an integer in the range 1:8, giving approximate
+            stellar classification"))
     end
     ub =  c1 + 2 * (m1 + by)
     # For group 1, beta is a luminosity indicator, c0 is a temperature indicator.

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -234,7 +234,7 @@ end
     glong, glat = @inferred(euler([0.45, 130], [16.28, 53.65], 5))
     @test glong ≈ [96.9525940157568, 138.09922696730337]
     @test glat ≈ [-43.90672396295434, 46.95527026543361]
-    @test_throws ErrorException @inferred(euler((45,45), 7))
+    @test_throws DomainError @inferred(euler((45,45), 7))
 end
 
 @testset "flux2mag" begin
@@ -346,7 +346,7 @@ end
     @test @inferred(gcirc(0, (120, -43), (175, +22)) )   ≈  1.590442261600714
     @test gcirc.(1, [120], [-43],  175, +22)             ≈ [415908.56615322345]
     @test gcirc.(2,  120, -43,  [175], [+22])            ≈ [296389.3666794745]
-    @test_throws ErrorException @inferred(gcirc(3, 0, 0, 0, 0))
+    @test_throws DomainError @inferred(gcirc(3, 0, 0, 0, 0))
 end
 
 @testset "hadec2altaz" begin
@@ -379,7 +379,7 @@ end
 # correlated with the output from helio routine of IDL AstroLib, with
 # differences only in the least significant digits (except for `hrad`` output of Mars)
 @testset "helio" begin
-    @test_throws ErrorException @inferred(helio(jdcnv(2005,07,17,2,6,9), 10))
+    @test_throws DomainError @inferred(helio(jdcnv(2005,07,17,2,6,9), 10))
     hrad_out, hlong_out, hlat_out = @inferred(helio(jdcnv(2000,08,23,0), 2, true))
     @test hrad_out ≈ 0.7213758288364316
     @test hlong_out ≈ 3.462574978561256
@@ -425,7 +425,7 @@ end
 # correlated with the output from imf routine of IDL AstroLib, with
 # differences only in the least significant digits.
 @testset "imf" begin
-    @test_throws ErrorException @inferred(imf([5], [-6.75], [0.9]))
+    @test_throws ArgumentError @inferred(imf([5], [-6.75], [0.9]))
     @test @inferred(imf([0.1, 0.01], [-0.6, -1], [ 0.007, 1.8, 110])) ≈
         [0.49627714725007616, 1.9757149090208912]
     @test imf.([[3],[5]], [[-1.35], [-0.6, -1.7]], [[0.1, 100], [0.007, 1.8, 110]]) ≈
@@ -509,8 +509,8 @@ end
     end
     @test kepler_solver.([pi/4, pi/6, 8pi/3], 0) ≈ [pi/4, pi/6, 2pi/3]
     @test @inferred(kepler_solver(0, 1)) == 0.0
-    @test_throws AssertionError @inferred(kepler_solver(pi, -0.5))
-    @test_throws AssertionError @inferred(kepler_solver(pi,  1.5))
+    @test_throws DomainError @inferred(kepler_solver(pi, -0.5))
+    @test_throws DomainError @inferred(kepler_solver(pi,  1.5))
 end
 
 @testset "lsf_rotate" begin
@@ -609,8 +609,8 @@ end
 # correlated with the output from planet_coord routine of IDL AstroLib, with
 # differences only in the least significant digits
 @testset "planet_coords" begin
-    @test_throws ErrorException @inferred(planet_coords(DateTime(2013, 07, 22,
-                                                                 03, 19, 06),0))
+    @test_throws DomainError @inferred(planet_coords(DateTime(2013, 07, 22,
+                                                              03, 19, 06),0))
     ra_out, dec_out = @inferred(planet_coords([AstroLib.J2000, 2.45e6], [2,8]))
     @test ra_out[1] ≈ 239.8965221579066
     @test ra_out[2] ≈ 294.55483837772476
@@ -642,7 +642,7 @@ end
     @test @inferred(posang(0, (120, -43), (175, +22)))    ≈ -1.5842896165356724
     @test posang.(1, [120], [-43],  175, +22)  ≈ [82.97831348792039]
     @test posang.(2,  120, -43,  [175], [+22]) ≈ [50.02816530382374]
-    @test_throws ErrorException @inferred(posang(3, 0, 0, 0, 0))
+    @test_throws DomainError @inferred(posang(3, 0, 0, 0, 0))
 end
 
 @testset "precess" begin
@@ -854,7 +854,7 @@ end
     @test trueanom.([pi/4, pi/6, 8pi/3], 0)            ≈ [pi/4, pi/6, 2pi/3]
     @test @inferred(trueanom(3pi/2, 0.8))              ≈ -2.498091544796509
     @test @inferred(trueanom(0.1, 1))                  ≈ pi
-    @test_throws AssertionError @inferred(trueanom(pi, -0.5))
+    @test_throws DomainError @inferred(trueanom(pi, -0.5))
     @test_throws DomainError @inferred(trueanom(pi,  1.5))
 end
 
@@ -862,7 +862,7 @@ end
 # correlated with the output from uvbybeta routine of IDL AstroLib, with
 # differences only in the least significant digits.
 @testset "uvbybeta" begin
-    @test_throws ErrorException @inferred uvbybeta(NaN, NaN, NaN, 9, NaN)
+    @test_throws DomainError @inferred uvbybeta(NaN, NaN, NaN, 9, NaN)
     te_o, mv_o, eby_o, delm_o, radius_o = @inferred uvbybeta(-0.009, 0.11, 0.68, 1)
     @test te_o ≈ 12719.770257555097
     @test mv_o ≈ -0.08913388245565224


### PR DESCRIPTION
`@assert` can get optimized away by the compiler, and generic `error()` uses `ErrorException`, which doesn't provide much information.

Used `DomainError` for an argument being outside a valid set, and used `ArgumentError` for multiple arguments relating to each other (e.g., multiple arrays having the same length).