### PR TITLE
Convert datetime to julian automatically in sunpos

### DIFF
--- a/src/sunpos.jl
+++ b/src/sunpos.jl
@@ -77,7 +77,7 @@ end
 sunpos(dt::DateTime; radians::Bool=false) =
     sunpos(datetime2julian(dt); radians=radians)
 sunpos(dt::AbstractVector{<:DateTime}; radians::Bool=false) =
-    sunpos(datetime2julian.(dt); radians)
+    sunpos(datetime2julian.(dt); radians=radians)
 
 """
     sunpos(jd[, radians=false]) -> ra, dec, elong, obliquity

--- a/src/sunpos.jl
+++ b/src/sunpos.jl
@@ -74,6 +74,11 @@ function sunpos(jd::AbstractVector{J}; radians::Bool=false) where {J<:Real}
     return ra, dec, longmed, oblt
 end
 
+sunpos(dt::DateTime; radians::Bool=false) =
+    sunpos(datetime2julian(dt); radians)
+sunpos(dt::AbstractVector{<:DateTime}; radians::Bool=false) =
+    sunpos(datetime2julian.(dt); radians)
+
 """
     sunpos(jd[, radians=false]) -> ra, dec, elong, obliquity
 
@@ -84,8 +89,8 @@ Compute the right ascension and declination of the Sun at a given date.
 ### Arguments ###
 
 * `jd`: the Julian date of when you want to calculate Sun position.  It can be
-  either a scalar or a vector.  Use `jdcnv` to get the Julian date for a given
-  date and time.
+  either a scalar or a vector.  If `jd` is a `Dates.DateTime` it will be
+  automatically converted.
 * `radians` (optional boolean keyword): if set to `true`, all output quantities
   are given in radians.  The default is `false`, so all quantities are given in
   degrees.

--- a/src/sunpos.jl
+++ b/src/sunpos.jl
@@ -75,7 +75,7 @@ function sunpos(jd::AbstractVector{J}; radians::Bool=false) where {J<:Real}
 end
 
 sunpos(dt::DateTime; radians::Bool=false) =
-    sunpos(datetime2julian(dt); radians)
+    sunpos(datetime2julian(dt); radians=radians)
 sunpos(dt::AbstractVector{<:DateTime}; radians::Bool=false) =
     sunpos(datetime2julian.(dt); radians)
 

--- a/test/utils-tests.jl
+++ b/test/utils-tests.jl
@@ -749,11 +749,13 @@ end
     @test dec ≈ 14.909699471099517
     @test lon ≈ 40.31067053890748
     @test obl ≈ 23.440840980112657
+    @test (ra, dec, lon, obl) === @inferred(sunpos(DateTime(1982, 5, 1)))
     ra, dec, lon, obl = @inferred(sunpos(jdcnv.([DateTime(2016, 5, 10)]), radians=true))
     @test ra  ≈ [0.8259691339090751]
     @test dec ≈ [0.3085047454107549]
     @test lon ≈ [0.8687853454154388]
     @test obl ≈ [0.40901175207670365]
+    @test (ra, dec, lon, obl) == @inferred(sunpos([DateTime(2016, 5, 10)], radians=true))
     ra, dec, lon, obl = @inferred(sunpos([2457531]))
     @test ra  ≈ [59.71655864208797]
     @test dec ≈ [20.52127006818727]


### PR DESCRIPTION
Implements #90 for the case of `sunpos` (perhaps there are other cases that should also be implemented). Because of the `::DateTime` type signature it is hard to misuse these methods (i.e. you can't accidentally pass a Julian date into them) so I think the cost of adding the implicit conversions is low. Especially compared to the convenience and risk of misusing explicit conversions. If AstroLib ever drops its dependency on Dates, these can move to a package extension. It's possible to implement this ever so slightly faster and with less code re-use to avoid allocating a vector to store the Julian dates I propose adding that optimization iff someone identifies this as a performance bottle neck.