### PR TITLE
Fix misleading example in sphdist.jl

### DIFF
--- a/src/sphdist.jl
+++ b/src/sphdist.jl
@@ -47,8 +47,8 @@ is expressed in radians unless `degrees` keyword is set to `true`.
 ```jldoctest
 julia> using AstroLib
 
-julia> sphdist(120, -43, 175, +22)
-1.5904422616007134
+julia> sphdist(120, -43, 175, +22, degrees=true)
+82.33037963318735
 ```
 
 ### Notes ###


### PR DESCRIPTION
Previously, `sphdist` was interpreting the numbers 120, -43, 175, and +22 as radians when they are obviously (IMO) intended to represent degrees.